### PR TITLE
Match AudioTick_Insert and func_8002F44C

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -49980,3 +49980,21 @@ level %= 0xC0;
 Written as one expression, `level = ((u32)Gp_LcgState >> 16) % 0xC0;`, the
 destination is a fresh quantity, the `subu` writes `v1`, and the scheduler
 hoists the next `lui` above the stores.
+## Saved-register coloring flipped by a parameter's width (AudioTick_Insert)
+
+Symptom: every instruction matched but a set of callee-saved regs (s0..s3) were
+assigned in a cyclic rotation vs the target — pure `regs=` penalty,
+`branch=insert=delete=0`. No C-level statement reorder or copy-direction swap
+moved it.
+
+Two independent tricks were needed:
+- The target kept two live copies of the same value (`sh` of the id early,
+  `andi id,0xffff` in the loop). Reproduce with two locals off the param,
+  `id16 = id; key = id16;` (store uses id16, loop uses key), plus a separate
+  walker pointer seeded after the alloc (`p = head;`) so the anchor `head` stays
+  in its own saved reg across the call.
+- The final coloring only matched once the priority tie was broken by narrowing
+  the parameter type (`u32 id` -> `u16 id`). Param width changes the entry
+  extension and the register the value first lands in, which reshuffles
+  local-alloc priorities. The permuter found this axis; it is worth trying
+  u16/s16 vs u32 on a value that is only ever used masked to 16 bits.

--- a/include/main/sound.h
+++ b/include/main/sound.h
@@ -745,7 +745,7 @@ void           Snd_ClearBanks(void);
 void           AsyncCb_Poll(void);
 void           AsyncCb_Reset(void);
 void           Spu_InitVoices(void);
-void           AudioTick_Insert(void*, u32, u32, s32*);
+s32            AudioTick_Insert(void*, u32, u16, s32*);
 void           SndEvt_Reset(void);
 s32            Midi_InitSystem(u32);
 s32            Midi_Tick(void);

--- a/src/main/sndbank.c
+++ b/src/main/sndbank.c
@@ -400,7 +400,60 @@ void Spu_ApplyPanVolume(s16* arg0, s16 arg1, s32 arg2)
     }
 }
 
-INCLUDE_ASM("main/nonmatchings/sndbank", AudioTick_Insert);
+s32 AudioTick_Insert(void* poll, u32 onRemove, u16 id, s32* arg)
+{
+    AudioTickNode* node;
+    AudioTickNode* head;
+    AudioTickNode* p;
+    AudioTickNode* next;
+    u16            id16;
+    u16            key;
+
+    id16 = id;
+    key  = id16;
+    head = &AudioTick_List;
+    if (head == NULL) {
+        return -1;
+    }
+    AudioTick_Enabled = 0;
+    node              = SndHeap_Malloc(sizeof(AudioTickNode));
+    if (node == NULL) {
+        AudioTick_Enabled = 1;
+        return -1;
+    }
+    node->poll     = (s32)poll;
+    node->onRemove = onRemove;
+    node->id       = id16;
+    node->arg      = (s32)arg;
+    node->prev     = 0;
+    node->next     = 0;
+
+    p = head;
+    for (;;) {
+        next = (AudioTickNode*)p->next;
+        if (next == NULL) {
+            p->next           = (s32)node;
+            node->prev        = (s32)p;
+            node->next        = 0;
+            AudioTick_Enabled = 1;
+            return 0;
+        }
+        if ((u16)next->id == key) {
+            SndHeap_Free(node);
+            AudioTick_Enabled = 1;
+            return -2;
+        }
+        if (key < (u16)next->id) {
+            node->next                      = (s32)next;
+            AudioTick_Enabled               = 1;
+            ((AudioTickNode*)p->next)->prev = (s32)node;
+            p->next                         = (s32)node;
+            node->prev                      = (s32)p;
+            return 0;
+        }
+        p = next;
+    }
+}
 
 void SndHeap_Reset(void)
 {

--- a/src/main/textdraw.c
+++ b/src/main/textdraw.c
@@ -650,7 +650,53 @@ u8* Text_ItoaHex(u8* arg0, u32 arg1)
     return ret;
 }
 
-INCLUDE_ASM("main/nonmatchings/textdraw", func_8002F44C);
+u8* func_8002F44C(u8* arg0, s32 arg1, s32 arg2)
+{
+    u8* p;
+    u32 place;
+    s32 val;
+    s32 count;
+    u32 limit;
+    u32 raw;
+    u32 digit;
+    s32 product;
+
+    val   = arg1;
+    count = arg2 - 1;
+    place = 1;
+    if (count > 0) {
+        do {
+            place *= 10;
+            count--;
+        } while (count > 0);
+    }
+    limit = place * 10 - 1;
+    if (limit < (u32)val) {
+        val = limit;
+    }
+    p = arg0;
+    if ((u32)val < place) {
+        do {
+            place /= 10;
+            *p     = 0x30;
+            p++;
+        } while ((u32)val < place);
+    }
+    if (place != 0) {
+        do {
+            raw     = (u32)val / place;
+            *p      = raw;
+            digit   = *p;
+            product = digit * place;
+            place  /= 10;
+            *p      = digit + 0x30;
+            p++;
+            val -= product;
+        } while (place != 0);
+    }
+    *p = 0;
+    return arg0;
+}
 
 u8* Text_SkipLines(u8* arg0, s32 arg1)
 {


### PR DESCRIPTION
Two main-executable functions decompiled to matching C, both previously `INCLUDE_ASM` on `main`:

- **`AudioTick_Insert`** (`src/main/sndbank.c`) — 14 attempts
- **`func_8002F44C`** (`src/main/textdraw.c`) — 5 attempts

`include/main/sound.h` gets a matching type tweak for `AudioTick_Insert`; a short `DECOMPILATION_LEARNINGS.md` entry is included.

Verified against your latest `main` (rebased onto `b23fdef`): a full unscoped `./tools/build-and-verify.sh` passes — `build/USA/out/SLUS_010.42: OK`, everything matched, no compiler or linter errors.

Scope is limited to these two functions; no tooling, config, or unrelated files touched.