### PR TITLE
shelter_1f_airlock: match func_shelter_1f_airlock_8017D6D0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,21 @@ running out of digits. Only the overlays with `rodata_head` split the id into a
 `<name>_hdr.rodata.s` - elsewhere it is folded into the first code unit's
 rodata, or, for rooms, sits as `D_<room>_8017D5C0`.
 
+**That id was almost certainly prepended by the packaging tool, not compiled.**
+The word at `0x4` is a pointer in overlay after overlay - a jump table, which
+GCC emits at the *start* of its object's `.rodata` - so the first translation
+unit begins at `0x4` and nothing owns `0x0..0x4`. A compiled id would mean 448
+generated one-line sources differing only by a constant, and that constant is a
+global packaging index (families in contiguous blocks) that a room's source
+could not know. The `u16`-in-a-`u32` shape fits a tool writing a `short` and
+padding for alignment.
+
+This matters for how to read `<name>_hdr.c`: those units reproduce the bytes,
+they do not reconstruct retail's file layout. A prepended header and a tiny
+first object are indistinguishable in the ROM, so the `_hdr.c` form is chosen
+because it matches, not because the original was split that way. Do not treat
+it as evidence about the original sources.
+
 Two maintenance commands, neither run by the build:
 
 - `python3 tools/gen_overlay_configs.py [--family F] [--list]` — regenerate the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,32 @@ subsegment, so a run at the *end* of a package - the zeroed work arrays - needs
 a unit of its own, conventionally `<name>_work`, declared after the `data`
 subsegment; a unit whose only subsegment is `.data` is compiled all the same.
 
+**`<name>_work` is for a *non-adjacent* run, not for zeroed data as such.** A
+unit appears once in the linker script, so it cannot span a hole: `p229` needs
+one because ~54KB of asm model data sits between its `0xF30` data run and its
+`0xE498` work array. Where the work array directly abuts the data run - every
+`pe` overlay - one unit covers both, with the objects declared in address order.
+
+**Those zeroed runs are bss by origin but must be `.data` in C, and the
+safe-looking alternative silently breaks the game.** An overlay is a flat LZSS
+image inflated straight to its load address (`doc/OVERLAYS.md` 4.2); the loader
+writes the image and zeroes nothing beyond it. So work state the code reads
+before writing has to be stored zeros *inside* the image - which is why the
+original build materialised its bss there, and why every package ends exactly at
+its last data byte. Declare such an array the natural way, `s16 work[16];`, and
+`-fcommon` turns it into a COMMON symbol that lands in the overlay's `.bss`; that
+section is `NOLOAD`, so it vanishes from the image and the overlay comes up
+reading whatever the previous overlay left at those addresses - with the build
+still green. Always write `= { 0 }`.
+
+`ld_bss_is_noload: True` in `configs/USA/overlay.template.yaml` cannot simply be
+turned off to avoid that. Setting it `False` fails the checksum on `tonfa_baton`,
+`acropolis_patio`, `dryfield_warehouse`, `dryfield_water_hole` and `mine_cavern`
+- none of which has a non-empty `.bss` or a single COMMON symbol. A loadable
+`.bss` output section participates in the image layout even when empty, and these
+images end flush against their last data byte with no slack for the alignment it
+introduces.
+
 Two maintenance commands, neither run by the build:
 
 - `python3 tools/gen_overlay_configs.py [--family F] [--list]` — regenerate the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,13 +151,17 @@ turned off to avoid that. Setting it `False` fails the checksum on `tonfa_baton`
 images end flush against their last data byte with no slack for the alignment it
 introduces.
 
-**The byte at offset 0 of a `pe` overlay is its spell index, as a character.**
-All twelve start with `'0' + index`, index being `(pe_level_ids - 50101) / 3` -
-`pyrokinesis` 0 through `energyball` 11. Indices 10 and 11 come out `:` and `;`
-rather than `10`/`11`, which is what proves it is computed as `'0' + n` and not
-a hand-written label. Only the five overlays with `rodata_head` split it into a
-`<name>_hdr.rodata.s`; the rest fold it into the first code unit's rodata, so an
-apparently-missing header string is not a difference in the data.
+**Every overlay starts with its own id: a `u16` at offset 0, in a `u32` slot.**
+All 448 packages carry a distinct value there, and the families sit in
+contiguous blocks - weapons 8-39, options 40, aya 43-45, pe 48-62, actors
+81-278, mapui 280-284, rooms 285-452. The high half is always zero.
+
+Do not read it as text. pe's block is 48-62, which is `0x30`-`0x3E`, so splat
+renders those bytes as `.asciz "0"` … `";"` and the id looks like a character
+scheme; it is not, and ids 58/59 printing as `:` and `;` is just the ASCII table
+running out of digits. Only the overlays with `rodata_head` split the id into a
+`<name>_hdr.rodata.s` - elsewhere it is folded into the first code unit's
+rodata, or, for rooms, sits as `D_<room>_8017D5C0`.
 
 Two maintenance commands, neither run by the build:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,17 @@ one because ~54KB of asm model data sits between its `0xF30` data run and its
 `0xE498` work array. Where the work array directly abuts the data run - every
 `pe` overlay - one unit covers both, with the objects declared in address order.
 
+**A second label on the same run is a second object, not `arr[1]`.** splat names
+an address the code references directly, so a two-vector run comes out as
+`D_x_A` plus `D_x_B`. Folding `D_x_B` into `D_x_A[1]` compiles and keeps the
+data bytes identical, and still fails: the original reaches that address both
+ways, and the two forms are different code. Indexing emits the array's address
+plus 8 (`addiu $v0,$v0,0xe704`), naming it emits its own (`addiu $v1,$v0,
+0xe70c`). Declare `SVECTOR D_x_A[1]` followed immediately by `SVECTOR D_x_B`,
+which reproduces both. `weapons/gunblade`, `m4a1_bayonet` and `tonfa_baton` are
+the worked examples; the same shape in `pe/energyshot` needed the opposite call,
+where a `(u16)` cast at the one use site was enough.
+
 **Those zeroed runs are bss by origin but must be `.data` in C, and the
 safe-looking alternative silently breaks the game.** An overlay is a flat LZSS
 image inflated straight to its load address (`doc/OVERLAYS.md` 4.2); the loader

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,14 @@ turned off to avoid that. Setting it `False` fails the checksum on `tonfa_baton`
 images end flush against their last data byte with no slack for the alignment it
 introduces.
 
+**The byte at offset 0 of a `pe` overlay is its spell index, as a character.**
+All twelve start with `'0' + index`, index being `(pe_level_ids - 50101) / 3` -
+`pyrokinesis` 0 through `energyball` 11. Indices 10 and 11 come out `:` and `;`
+rather than `10`/`11`, which is what proves it is computed as `'0' + n` and not
+a hand-written label. Only the five overlays with `rodata_head` split it into a
+`<name>_hdr.rodata.s`; the rest fold it into the first code unit's rodata, so an
+apparently-missing header string is not a difference in the data.
+
 Two maintenance commands, neither run by the build:
 
 - `python3 tools/gen_overlay_configs.py [--family F] [--list]` — regenerate the

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52406,3 +52406,40 @@ substitute, and `color` keeps exactly its three references (`move` plus two
 confirms the width (`lh a1, 0x26(s1)` and a `sll`/`sra`-extended `lhu` of
 `0x24` into `a2`), so prefer `s16` parameters whenever a `sll 16` / `sra`
 pair re-extends an argument the prologue also copied.
+
+## `(p + i)[col * 16]` puts the row term first; `arr[col][i]` puts it second
+
+`func_plasma_8012F568` reads jitter column `arg2`, entry `i`, of a
+`s16 [3][16]` table. The target forms the address as
+
+```
+sll  v0, s4, 1        # i * 2 first
+sll  v1, t8, 5        # arg2 * 32 second
+addu v0, v0, v1
+addu v0, v0, t7       # + table
+```
+
+`((s16(*)[16])&table)[arg2][i]` scored 99.8% with the two `sll`s swapped, and
+`((s16*)&table)[i + arg2 * 16]` was worse (it folds to one `(arg2*16 + i) << 1`
+chain). GCC's `fold` splits a sum into its variable and constant parts and
+re-emits it as `vars + const`, so the `SYMBOL_REF` base always lands last and the
+variable terms keep their *source* order. `arr[col][i]` is `base + col*32 + i*2`;
+to get `i*2` first, add `i` to the base first and index the result by the row:
+
+```c
+idx = ((&D_plasma_8012FF54.a + i)[arg2 * 16] + arg0->field_22) % 6;
+```
+
+Same instructions, same `addu` operands, 100%. This is the array-index cousin
+of "`addu` load order and operand order are coupled": both terms are computed,
+not loaded, so only the fold order can be steered.
+
+The same function's prologue was then off by one local-alloc colouring
+(`head` in `$v0`/`r1` in `$a0` instead of `$a0`/`$a1`) that no reshaping of the
+three statements involved would move. What fixed it was hoisting the *unrelated*
+radius arithmetic (`r1 += row->rInner; r0 = r1 + …`) above the
+`G_SCRATCH_HEAD` load/store block. The instructions still schedule identically,
+but sched1 breaks its ties by source position, the `rInner` temp is born
+earlier relative to `head`, and local-alloc's priority order flips so `rInner`
+takes `$v0` before `head` is coloured. When a colouring diff resists every
+edit of the statements it names, move the neighbours instead.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52336,3 +52336,40 @@ and `volatile` casts the same way — each one is a scheduling fence
 (`sched_analyze` orders everything around an `ASM_INPUT`), so a `%hi` or
 split-constant `lui` that the target hoists to the prologue cannot cross it.
 Rewrite from the nearest matched sibling's shape, then look at dumps.
+
+## A volatile halfword reload is `lhu` + `sll`/`sra`, never `lh`; separate it from the store with an unrelated global store instead
+
+`func_combustion_8012F888`'s archived seed stored `mem->field_2A = kind` and
+read it straight back through `((volatile GpEffWork*)mem)->field_2A` so the
+reload would not be forwarded from `kind`. That reload can only ever be
+`lhu; sll 16; sra 10`: MIPS `extendhisi2` expands an optimised `sign_extend
+(mem:HI)` as a plain `movhi` load plus two shifts, and it is *combine* that
+folds the pair back into one `lh` - which it refuses to do for a volatile
+`mem`. The target had `lh v1; sll v1, 6`, so the volatile was the whole 2%.
+
+Non-volatile, CSE turns the reload into `sll/sra` of the stored register (or a
+bare `move` when the store operand is already `HImode`). A memory clobber
+between the two keeps the `lh` but also fences the block, and the target
+sinks both `Gp_LcgState = rng; Gp_LcgState = rng2;` stores below the reload.
+What matches is putting one of those global stores between the field store and
+the field reload in the source:
+
+```c
+mem->field_2A = kind;
+Gp_LcgState   = rng;        /* any store CSE cannot prove disjoint */
+tmp           = mem->field_2A;   /* s32 tmp: keeps the sign_extend → lh */
+mem->field_12 = -hi - (tmp << 6);
+Gp_LcgState   = rng2;
+```
+
+A `sw` to a symbol invalidates every register-based `mem` in the hash table,
+so the reload survives, and sched2 still floats both `sw`s down to where the
+target has them. Keep the `s32 tmp`: `-hi - (mem->field_2A << 6)` stored into
+an `s16` narrows the shift to `HImode` and the load becomes `lhu`.
+
+The last instruction was a second reload of the same field after
+`arg0->state = …` that the target keeps as two loads (`lh v0; lh v1`). Both
+survive CSE - the `sw` through `arg0` invalidates them - but when both reads
+use one `tmp` local they colour to the same hard register and `reload_cse`
+deletes the second `lh` as a self-copy. Give the second read its own local
+(`tmp2`) so it lands in `$v1` and the load is emitted.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52443,3 +52443,32 @@ but sched1 breaks its ties by source position, the `rInner` temp is born
 earlier relative to `head`, and local-alloc's priority order flips so `rInner`
 takes `$v0` before `head` is coloured. When a colouring diff resists every
 edit of the statements it names, move the neighbours instead.
+
+### CSE only follows a branch whose target label has exactly one use
+
+Two reads of the same global inside one case arm, with a state check between
+them, came out with the `lui %hi` shared across the check and the just-stored
+halfword reused from its register (`sll/sra` instead of a fresh `lh`). The
+target re-emitted `lui / addiu` at the second read and reloaded the halfword,
+which looks like a barrier but is not one.
+
+`cse_end_of_basic_block` (GCC 2.8.1 `cse.c`) extends a block through a
+conditional jump - "follow" when a `BARRIER` precedes the target, "skip" when
+the jump goes around a label-free run - only when
+`LABEL_NUSES (JUMP_LABEL (p)) == 1`. `if (X != K) { if (A || B) goto dec; }`
+gives the compare block after the `}` one incoming jump, so the `X == K` test
+is skipped around and the second read lands in the first block's CSE table.
+Write the release body *inline* under `if (X != K && (A || B)) { ... return; }`
+instead: at cse time the block after it has two incoming jumps (`X == K` and
+`!B`), nothing follows it, and no sharing happens. Cross-jumping in jump2 then
+folds the inline copy into the shared tail and `jump_optimize` turns the
+leftover `if (B) goto next; j dec` back into `beqz ..., dec`, so the final
+layout is identical to the `goto` version except for the unshared `lui` and
+the reload. `func_energyball_8012F180` cases 3 and 4 are the example (99.19% →
+100% by this change alone). A `COMPILER_BARRIER()` gets the reload but not the
+`lui`; a `tbl = D_x; SOFT_TOUCH_REG(tbl)` guards the pointer, not its `high`
+pseudo, so neither reproduces it.
+
+Also from the same function: `&Gp_RoomCoords[arg0->spawnArg1 + 4]` assembles
+to the same bytes as the splat name `D_801150C0` (`%lo(Gp_RoomCoords+0x190)`),
+so a "slot base four entries in" needs no separate extern.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52472,3 +52472,40 @@ pseudo, so neither reproduces it.
 Also from the same function: `&Gp_RoomCoords[arg0->spawnArg1 + 4]` assembles
 to the same bytes as the splat name `D_801150C0` (`%lo(Gp_RoomCoords+0x190)`),
 so a "slot base four entries in" needs no separate extern.
+
+## `if (*p != x) p++; else return 1` keeps `bne` and a mid-loop `return 1`
+
+A membership walk of a `u16` table written as the natural
+
+```c
+do {
+    if (*p == arg0) {
+        return 1;
+    }
+    p++;
+    i++;
+} while (i < N);
+```
+
+inverts to `beq` plus a `jr ra; li v0, 1` *after* the miss `return 0`. The
+target falls through to `return 1` and takes `bne` to the miss path (`slti` /
+`bnez` loop-back, pointer increment in that delay). Invert the test and put
+the walker in the true arm; increment `i` *before* the `if` so it fills the
+`bne` delay (the `lhu` delay stays a `nop`):
+
+```c
+p = table;
+i = 0;
+do {
+    i++;
+    if (*p != arg0) {
+        p++;
+    } else {
+        return 1;
+    }
+} while (i < N);
+return 0;
+```
+
+Indexing `table[i]` also inverts the branch and swaps the pointer/`i`
+registers. `func_replay_bonus_80117598` is the example.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52373,3 +52373,36 @@ survive CSE - the `sw` through `arg0` invalidates them - but when both reads
 use one `tmp` local they colour to the same hard register and `reload_cse`
 deletes the second `lh` as a self-copy. Give the second read its own local
 (`tmp2`) so it lands in `$v1` and the load is emitted.
+
+## An `s16` copy of an `s16` parameter survives cse; an `s32` one needs a dead store
+
+`func_energyball_8012FFD0` (an overlay copy of `Gp_DrawRing` with a flat tint)
+keeps a copy of its third argument in `$fp` for the loop's `sb` while the
+`(s16)arg2 >> 1` before the loop still reads `$a2`:
+
+```
+move  fp, a2            /* prologue */
+...
+sll   v0, a2, 16        /* half, in the loop preheader */
+sra   s5, v0, 17
+sb    fp, 0x15(s0)      /* colour, inside the loop */
+```
+
+With `s32 arg2` and `s32 color = arg2;` the copy is a plain SI move and cse1
+makes `color` the canonical name of the pair (its last use is later - see "A
+dead store keeps `x` (not `y`) the cse-canonical name"), so the `sll` reads
+the copy instead and `color` picks up a fourth reference, which lifts it above
+the two hoisted mask constants and puts it in `$s6`. `SOFT_TOUCH_REG(color)`
+blocks the substitution but adds two references of its own, with the same
+mis-colouring; only a dead `arg2 = 0;` after the loop gave 100%.
+
+Declaring both as `s16` needs no hack. A `s16` parameter is *not* promoted in
+GCC 2.8.1: it is a `HImode` pseudo set from a `subreg:HI` of the `SImode`
+entry copy, and `s16 color = arg2;` is a `HImode` move of that pseudo. The
+sign-extending `arg2 >> 1` is expanded from the `SImode` entry copy, so the
+two reads are in different modes, cse has no same-mode register to
+substitute, and `color` keeps exactly its three references (`move` plus two
+`sb`) - which is what drops it to the last callee-saved slot. The caller
+confirms the width (`lh a1, 0x26(s1)` and a `sll`/`sra`-extended `lhu` of
+`0x24` into `a2`), so prefer `s16` parameters whenever a `sll 16` / `sra`
+pair re-extends an argument the prologue also copied.

--- a/configs/USA/overlays.toml
+++ b/configs/USA/overlays.toml
@@ -62,11 +62,11 @@ imports = "configs/USA/sym/weapons.imports.txt"
 [weapons.overlays]
 as12 = { item = 0x8E, weapon = "AS12", rodata_head = "0x4" }
 grenade_pistol = { item = 0x8A, weapon = "Grenade Pistol", rodata = [{ start = "0x4", unit = "grenade_pistol_3" }], shared = [{ start = "0x1E0", end = "0x53C", unit = "weapons_shared_8011d3a0" }, { start = "0x9A0", end = "0x9CC", unit = "weapons_shared_8011ddf8" }, { start = "0x9CC", end = "0xA10", unit = "weapons_shared_8011de24" }], data = [{ start = "0xA74" }, { start = "0xE260", unit = "grenade_pistol_work" }, { start = "0xE27C" }] }
-gunblade = { item = 0x96, weapon = "Gunblade", rodata = [{ start = "0x4", unit = "gunblade_2" }], units = ["0xE80"], data = [{ start = "0x11084", unit = "gunblade_work" }] }
+gunblade = { item = 0x96, weapon = "Gunblade", rodata = [{ start = "0x4", unit = "gunblade_2" }], units = ["0xE80"], data = [{ start = "0x1544", unit = "gunblade" }, { start = "0x1554" }, { start = "0x11084", unit = "gunblade_work" }] }
 hypervelocity = { item = 0x95, weapon = "Hypervelocity", rodata_head = "0x4", rodata = [{ start = "0x18", unit = "hypervelocity_3" }], shared = [{ start = "0x1F5C", end = "0x1FA8", unit = "weapons_shared_8011e4ac" }, { start = "0x24E0", end = "0x2500", unit = "weapons_shared_8011db78" }], data = [{ start = "0x29B4", unit = "hypervelocity" }, { start = "0x29BC" }, { start = "0x11D4C", unit = "hypervelocity_work" }] }
 m249 = { item = 0x90, weapon = "M249", rodata_head = "0x4" }
 m4a1 = { item = 0x8F, weapon = "M4A1 Rifle" }
-m4a1_bayonet = { item = 0x99, weapon = "M4A1 Bayonet", rodata_head = "0x4", rodata = [{ start = "0x4", unit = "m4a1_bayonet_2" }], units = ["0x874"], data = [{ start = "0x101D8", unit = "m4a1_bayonet_work" }] }
+m4a1_bayonet = { item = 0x99, weapon = "M4A1 Bayonet", rodata_head = "0x4", rodata = [{ start = "0x4", unit = "m4a1_bayonet_2" }], units = ["0x874"], data = [{ start = "0xD08", unit = "m4a1_bayonet" }, { start = "0xD18" }, { start = "0x101D8", unit = "m4a1_bayonet_work" }] }
 m4a1_grenade = { item = 0x9A, weapon = "M4A1 Grenade", rodata_head = "0x4", rodata = [{ start = "0x1C", unit = "m4a1_grenade_2" }], shared = [{ start = "0xC38", end = "0xC64", unit = "weapons_shared_8011ddf8" }, { start = "0xC64", end = "0xCA8", unit = "weapons_shared_8011de24" }], data = [{ start = "0xD0C" }, { start = "0x10ECC", unit = "m4a1_grenade_work" }, { start = "0x10ED4" }] }
 m4a1_hammer = { item = 0x98, weapon = "M4A1 Hammer", rodata_head = "0x4", rodata = [{ start = "0x4", unit = "m4a1_hammer_2" }], units = ["0x1550"], data = [{ start = "0x19A0", unit = "m4a1_hammer" }, { start = "0x19A8" }, { start = "0x10470", unit = "m4a1_hammer_work" }] }
 m4a1_javelin = { item = 0x9C, weapon = "M4A1 Javelin", rodata_head = "0x4", data = [{ start = "0x28D0", unit = "m4a1_javelin" }, { start = "0x28F4" }, { start = "0x119A0", unit = "m4a1_javelin_work" }] }
@@ -85,7 +85,7 @@ p08_snail = { item = 0x80, weapon = "P08(S. Magazine)", rodata_head = "0x4" }
 p229 = { item = 0x84, weapon = "P229", rodata = [{ start = "0x4", unit = "p229_2" }], shared = [{ start = "0x2A4", end = "0x6A0", unit = "weapons_shared_8011d468" }, { start = "0x6A0", end = "0xBE0", unit = "weapons_shared_8011d864" }], data = [{ start = "0xF30", unit = "p229" }, { start = "0xF38" }, { start = "0xE498", unit = "p229_work" }] }
 pa3 = { item = 0x8C, weapon = "PA3", rodata_head = "0x4" }
 sp12 = { item = 0x8D, weapon = "SP12", rodata_head = "0x4" }
-tonfa_baton = { item = 0x92, weapon = "Tonfa Baton", rodata = [{ start = "0x4", unit = "tonfa_baton_2" }], shared = [{ start = "0x9B8", end = "0x9D8", unit = "weapons_shared_8011db78" }], data = [{ start = "0xEA2C", unit = "tonfa_baton_work" }] }
+tonfa_baton = { item = 0x92, weapon = "Tonfa Baton", rodata = [{ start = "0x4", unit = "tonfa_baton_2" }], shared = [{ start = "0x9B8", end = "0x9D8", unit = "weapons_shared_8011db78" }], data = [{ start = "0xF30", unit = "tonfa_baton" }, { start = "0xF40" }, { start = "0xEA2C", unit = "tonfa_baton_work" }] }
 unused_85 = { item = 0x85, weapon = "", note = "unused weapon slot 0x85" }
 unused_86 = { item = 0x86, weapon = "", note = "unused weapon slot 0x86" }
 unused_87 = { item = 0x87, weapon = "", note = "unused weapon slot 0x87" }

--- a/configs/USA/overlays.toml
+++ b/configs/USA/overlays.toml
@@ -623,7 +623,7 @@ pyrokinesis = { pe_level_ids = "50101-50103", rodata_head = "0x4", shared = [{ s
 combustion = { pe_level_ids = "50104-50106", shared = [{ start = "0xBE4", end = "0xFDC", unit = "pe_shared_8012fb14" }], data = [{ start = "0x1A50", unit = "combustion" }] }
 inferno = { pe_level_ids = "50107-50109", rodata_head = "0x4", data = [{ start = "0x15B4", unit = "inferno" }] }
 necrosis = { pe_level_ids = "50110-50112", data = [{ start = "0x178C", unit = "necrosis" }] }
-plasma = { pe_level_ids = "50113-50115" }
+plasma = { pe_level_ids = "50113-50115", data = [{ start = "0x1004", unit = "plasma" }] }
 apobiosis = { pe_level_ids = "50116-50118", rodata_head = "0x4", data = [{ start = "0x1C2C", unit = "apobiosis" }] }
 metabolism = { pe_level_ids = "50119-50121", data = [{ start = "0xC24", unit = "metabolism" }] }
 healing = { pe_level_ids = "50122-50124", shared = [{ start = "0x564", end = "0x6B4", unit = "pe_shared_8012f9a8" }], data = [{ start = "0xCEC", unit = "healing" }] }

--- a/configs/USA/overlays.toml
+++ b/configs/USA/overlays.toml
@@ -619,18 +619,18 @@ global_vram_end   = 0x8012EF30
 imports = "configs/USA/sym/pe.imports.txt"
 
 [pe.overlays]
-pyrokinesis = { pe_level_ids = "50101-50103", rodata_head = "0x4", shared = [{ start = "0x1E90", end = "0x2288", unit = "pe_shared_8012fb14" }] }
-combustion = { pe_level_ids = "50104-50106", shared = [{ start = "0xBE4", end = "0xFDC", unit = "pe_shared_8012fb14" }] }
-inferno = { pe_level_ids = "50107-50109", rodata_head = "0x4" }
-necrosis = { pe_level_ids = "50110-50112" }
+pyrokinesis = { pe_level_ids = "50101-50103", rodata_head = "0x4", shared = [{ start = "0x1E90", end = "0x2288", unit = "pe_shared_8012fb14" }], data = [{ start = "0x2EA8", unit = "pyrokinesis" }] }
+combustion = { pe_level_ids = "50104-50106", shared = [{ start = "0xBE4", end = "0xFDC", unit = "pe_shared_8012fb14" }], data = [{ start = "0x1A50", unit = "combustion" }] }
+inferno = { pe_level_ids = "50107-50109", rodata_head = "0x4", data = [{ start = "0x15B4", unit = "inferno" }] }
+necrosis = { pe_level_ids = "50110-50112", data = [{ start = "0x178C", unit = "necrosis" }] }
 plasma = { pe_level_ids = "50113-50115" }
-apobiosis = { pe_level_ids = "50116-50118", rodata_head = "0x4" }
-metabolism = { pe_level_ids = "50119-50121" }
-healing = { pe_level_ids = "50122-50124", shared = [{ start = "0x564", end = "0x6B4", unit = "pe_shared_8012f9a8" }] }
-lifedrain = { pe_level_ids = "50125-50127", rodata_head = "0x4", shared = [{ start = "0xA78", end = "0xBC8", unit = "pe_shared_8012f9a8" }, { start = "0x1690", end = "0x1990", unit = "pe_shared_801305c0" }] }
-antibody = { pe_level_ids = "50128-50130", shared = [{ start = "0x19A4", end = "0x1CA4", unit = "pe_shared_801305c0" }] }
-energyshot = { pe_level_ids = "50131-50133", shared = [{ start = "0x820", end = "0xB20", unit = "pe_shared_801305c0" }] }
-energyball = { pe_level_ids = "50134-50136", rodata_head = "0x4" }
+apobiosis = { pe_level_ids = "50116-50118", rodata_head = "0x4", data = [{ start = "0x1C2C", unit = "apobiosis" }] }
+metabolism = { pe_level_ids = "50119-50121", data = [{ start = "0xC24", unit = "metabolism" }] }
+healing = { pe_level_ids = "50122-50124", shared = [{ start = "0x564", end = "0x6B4", unit = "pe_shared_8012f9a8" }], data = [{ start = "0xCEC", unit = "healing" }] }
+lifedrain = { pe_level_ids = "50125-50127", rodata_head = "0x4", shared = [{ start = "0xA78", end = "0xBC8", unit = "pe_shared_8012f9a8" }, { start = "0x1690", end = "0x1990", unit = "pe_shared_801305c0" }], data = [{ start = "0x1B84", unit = "lifedrain" }] }
+antibody = { pe_level_ids = "50128-50130", shared = [{ start = "0x19A4", end = "0x1CA4", unit = "pe_shared_801305c0" }], data = [{ start = "0x1CA4", unit = "antibody" }] }
+energyshot = { pe_level_ids = "50131-50133", shared = [{ start = "0x820", end = "0xB20", unit = "pe_shared_801305c0" }], data = [{ start = "0x11B4", unit = "energyshot" }] }
+energyball = { pe_level_ids = "50134-50136", rodata_head = "0x4", data = [{ start = "0x224C", unit = "energyball" }] }
 
 # The tail sits at the same stride-3 spacing (slots 15, 16, 17 of the same
 # enumeration), which lines up with the three items after the four passive
@@ -642,4 +642,4 @@ energyball = { pe_level_ids = "50134-50136", rodata_head = "0x4" }
 # (`Gp_AddTpageShift`) that suits a gas spray.
 ofuda        = { pe_slot = 15, ambiguous = true }
 flare        = { pe_slot = 16, ambiguous = true }
-pepper_spray = { pe_slot = 17, ambiguous = true }
+pepper_spray = { pe_slot = 17, ambiguous = true, data = [{ start = "0xC6C", unit = "pepper_spray" }] }

--- a/configs/USA/overlays.toml
+++ b/configs/USA/overlays.toml
@@ -630,7 +630,7 @@ healing = { pe_level_ids = "50122-50124", shared = [{ start = "0x564", end = "0x
 lifedrain = { pe_level_ids = "50125-50127", rodata_head = "0x4", shared = [{ start = "0xA78", end = "0xBC8", unit = "pe_shared_8012f9a8" }, { start = "0x1690", end = "0x1990", unit = "pe_shared_801305c0" }] }
 antibody = { pe_level_ids = "50128-50130", shared = [{ start = "0x19A4", end = "0x1CA4", unit = "pe_shared_801305c0" }] }
 energyshot = { pe_level_ids = "50131-50133", shared = [{ start = "0x820", end = "0xB20", unit = "pe_shared_801305c0" }] }
-energyball = { pe_level_ids = "50134-50136" }
+energyball = { pe_level_ids = "50134-50136", rodata_head = "0x4" }
 
 # The tail sits at the same stride-3 spacing (slots 15, 16, 17 of the same
 # enumeration), which lines up with the three items after the four passive

--- a/include/aya/replay_bonus.h
+++ b/include/aya/replay_bonus.h
@@ -7,6 +7,11 @@
 
 #include "main/ui.h"
 
+/// Replay-bonus item-id table (`0x4E` ids, then a `0xFFFF` terminator).
+/// `func_replay_bonus_80117598` tests membership; `func_replay_bonus_80115D60`
+/// walks the same list when filling `ReplayBonusItemList`.
+extern u16 D_replay_bonus_8011908C[];
+
 /// The list of item ids the replay-bonus screen offers. `func_replay_bonus_80115D60`
 /// fills `itemIds` (one `s16` per unlocked item); `func_replay_bonus_801175D0` and
 /// `func_replay_bonus_801175F0` read it back, treating an id below 0x100 as an index

--- a/include/pe/energyball.h
+++ b/include/pe/energyball.h
@@ -6,12 +6,37 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+#include "gameplay/3A34.h"
+
 /// `SndEvt` ids for the energy ball, indexed by `GpEffWork.field_20`
 /// (`Gp_StateC08.field_0 % 10 - 1`, so the sound scales with the combo
 /// counter). The first three are the charge loop `func_energyball_8012EF48`
 /// starts with `SndEvt_EnqueueType6`; the last three are the matching `...0001`
 /// variants.
 extern s32 D_energyball_8013117C[];
+
+/// One 4-byte row of `D_energyball_80131194`, indexed by `GpEffWork.field_20`
+/// (`Gp_StateC08.field_0 % 10 - 1`). `field_0` is the full size the ball grows
+/// to before it is launched (`GpEffWork.field_26`; half of it is the linked
+/// `GpObj.field_1C` radius, twice it the burst's final size) and `field_2` the
+/// per-frame growth step, also the initial upward speed while charging.
+typedef struct EnergyBallStep {
+    /* 0x0 */ s16 field_0;
+    /* 0x2 */ s16 field_2;
+} EnergyBallStep;
+STATIC_ASSERT_SIZEOF(EnergyBallStep, 4);
+
+/// Collision block allocated by `func_energyball_8012F180` (`Mem_Calloc(0x38)`)
+/// and stored in `Task::idMap`: `obj` is linked on list 1 with `field_C`
+/// pointing at the one-element `rec` table (terminator `field_0 = 2`).
+typedef struct EnergyBallWork {
+    /* 0x00 */ GpObj   obj;
+    /* 0x20 */ GpRec18 rec;
+} EnergyBallWork;
+STATIC_ASSERT_SIZEOF(EnergyBallWork, 0x38);
+
+/// Three energy ball charge levels, weakest first.
+extern EnergyBallStep D_energyball_80131194[];
 
 /// Sixteen 8-bit draws from `Gp_LcgState`, refilled once per cast by
 /// `func_energyball_8012EF48` and consumed by the GTE pass in
@@ -77,5 +102,12 @@ STATIC_ASSERT_SIZEOF(EnergyGroundScratch, 0x30);
 /// the frame picked by the low bit of `Display_State.field_8`, tinted
 /// `(0x20, 0x30, 0x20)`.
 void func_energyball_801307D4(GsCOORDINATE2* arg0, s32 arg1);
+
+/// Draws the energy ball's surface: two 16-vertex rings of the same radius
+/// sit `arg1 * 2` apart in `arg0`'s local Y, are rotated by its `workm` and
+/// offset by its translation, then each of the 16 segments is projected
+/// through `GsWSMATRIX` as one semi-transparent `POLY_FT4`, tinted
+/// `(arg2 >> 1, arg2, arg2 >> 1)`.
+void func_energyball_80130B54(GsCOORDINATE2* arg0, s16 arg1, s16 arg2);
 
 #endif /* PE_ENERGYBALL_H */

--- a/include/pe/energyball.h
+++ b/include/pe/energyball.h
@@ -48,6 +48,12 @@ STATIC_ASSERT_SIZEOF(EnergyQuadScratch, 0x1C);
 /// `arg3 + 0x400`, so the sprite shrinks with depth.
 void func_energyball_8013035C(GsCOORDINATE2* arg0, s16 arg1, s16 arg2, s16 arg3);
 
+/// Overlay copy of `Gp_DrawRing` with a flat tint: an eight-segment gouraud
+/// ring at `arg0`'s world position, radius `arg1 * 64 / otz`, lit only at the
+/// centre with `(arg2 / 2, arg2, arg2 / 2)`, each wedge given the
+/// semi-transparent tpage of `Gp_AddTpageShift`.
+void func_energyball_8012FFD0(GsCOORDINATE2* arg0, s16 arg1, s16 arg2);
+
 /// 0x30-byte scratch from `G_SCRATCH_HEAD` used by `func_energyball_801307D4`
 /// for the ground-plane quad. `vec` holds the four corners of the unit quad
 /// `D_80111E38`, scaled to the caller's half-size, rotated flat by

--- a/include/pe/energyshot.h
+++ b/include/pe/energyshot.h
@@ -19,7 +19,6 @@ STATIC_ASSERT_SIZEOF(EnergyShotScale, 8);
 extern EnergyShotScale D_energyshot_801300E4[];
 /// Splat-split last half of the third `D_energyshot_801300E4` row (`field_6` of
 /// index 2). State 1's `field_20 == 2` beam pass shifts this as a bare `u16`.
-extern u16 D_energyshot_801300FA;
 /// The `SndEvt_EnqueueType6` id for each `D_energyshot_801300E4` row.
 extern s32 D_energyshot_801300FC[];
 

--- a/include/pe/plasma.h
+++ b/include/pe/plasma.h
@@ -36,10 +36,34 @@ typedef struct PlasmaJitter {
 } PlasmaJitter;
 STATIC_ASSERT_SIZEOF(PlasmaJitter, 0x60);
 
+/// Per-ring radius scale for `func_plasma_8012F568`, indexed by ring number
+/// (0..2). `rInner` widens the inner radius (`GpEffWork::field_26`), `rExtra`
+/// the outer radius on top of that (`+ field_2A`), and `yOff` raises the
+/// inner edge above `field_28`.
+typedef struct PlasmaRingScale {
+    /* 0x0 */ s16 rInner;
+    /* 0x2 */ s16 yOff;
+    /* 0x4 */ s16 rExtra;
+} PlasmaRingScale;
+STATIC_ASSERT_SIZEOF(PlasmaRingScale, 0x6);
+
+extern PlasmaRingScale D_plasma_8012FF34[];
+
 /// `SndEvt` ids for the plasma ring, indexed by `Gp_StateC08.field_0 % 10 - 1`.
 extern s32 D_plasma_8012FF48[];
 
 extern PlasmaJitter D_plasma_8012FF54;
+
+/// Draws textured band `arg2` (0..2) of the plasma ring around `arg1`: sixteen
+/// `POLY_FT4` wedges between an outer circle of radius
+/// `field_26 + rInner + field_2A + rExtra` and an inner one of radius
+/// `field_26 + rInner`, the outer ring lifted by `-(field_28 + yOff)`. Both
+/// circles are rotated by the coordinate's `workm`, translated by its `t[]`
+/// and projected through `GsWSMATRIX`; wedge `i` picks its texture column
+/// from `(D_plasma_8012FF54[arg2][i] + field_22) % 6`, and `field_24` sets the
+/// brightness. A negative `gte_stflg` on the wedge's first vertex drops it.
+/// Works out of a `GpBandScratch` taken from `G_SCRATCH_HEAD`.
+void func_plasma_8012F568(GpEffWork* arg0, GsCOORDINATE2* arg1, s32 arg2);
 
 /// Projects `arg0`'s world position and queues sixteen gouraud `POLY_G4`
 /// wedges forming a ring around it. `arg1` is the inner half-extent and

--- a/include/weapons/gunblade.h
+++ b/include/weapons/gunblade.h
@@ -47,7 +47,7 @@ STATIC_ASSERT_SIZEOF(GunbladeBeamScratch, 0x2C);
 /// array base already in a register; state 1 loads the symbol on its own. Both
 /// spellings are needed to match, and one object cannot carry two C names, so
 /// the pair stays in the split data.
-extern SVECTOR D_gunblade_8011E704[2];
+extern SVECTOR D_gunblade_8011E704[1];
 extern SVECTOR D_gunblade_8011E70C;
 
 /// The eight-segment beam trails, one array per end of the blade. Every entry

--- a/include/weapons/m4a1_bayonet.h
+++ b/include/weapons/m4a1_bayonet.h
@@ -10,7 +10,7 @@
 /// the thrust is winding up and `[1]` `(0, 0x180, 0x40)` the hilt. The second
 /// element is also labelled `D_m4a1_bayonet_8011DED0` because the sweep state
 /// addresses it as a symbol of its own.
-extern SVECTOR D_m4a1_bayonet_8011DEC8[2];
+extern SVECTOR D_m4a1_bayonet_8011DEC8[1];
 
 /// `D_m4a1_bayonet_8011DEC8[1]` under its own label. State 0 reaches the hilt
 /// through the array base already in a register, the sweep state loads this

--- a/include/weapons/tonfa_baton.h
+++ b/include/weapons/tonfa_baton.h
@@ -49,7 +49,7 @@ STATIC_ASSERT_SIZEOF(TonfaSwing, 0x18);
 /// from the array base already in a register; state 1 loads the symbol on its
 /// own. Both spellings are needed to match, and one object cannot carry two C
 /// names, so the pair stays in the split data.
-extern SVECTOR D_tonfa_baton_8011E0F0[2];
+extern SVECTOR D_tonfa_baton_8011E0F0[1];
 extern SVECTOR D_tonfa_baton_8011E0F8;
 
 /// The eight-segment swing trails, one array per end of the baton. Every entry

--- a/src/aya/replay_bonus/replay_bonus.c
+++ b/src/aya/replay_bonus/replay_bonus.c
@@ -46,7 +46,23 @@ INCLUDE_ASM("aya/nonmatchings/replay_bonus/replay_bonus", func_replay_bonus_8011
 
 INCLUDE_ASM("aya/nonmatchings/replay_bonus/replay_bonus", func_replay_bonus_80117484);
 
-INCLUDE_ASM("aya/nonmatchings/replay_bonus/replay_bonus", func_replay_bonus_80117598);
+s32 func_replay_bonus_80117598(s32 arg0)
+{
+    u16* p;
+    s32  i;
+
+    p = D_replay_bonus_8011908C;
+    i = 0;
+    do {
+        i++;
+        if (*p != arg0) {
+            p++;
+        } else {
+            return 1;
+        }
+    } while (i < 0x4E);
+    return 0;
+}
 
 s16 func_replay_bonus_801175D0(UiList* list, ReplayBonusCtx* ctx, s32 index)
 {

--- a/src/pe/antibody/antibody.c
+++ b/src/pe/antibody/antibody.c
@@ -16,6 +16,16 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// Per-level tuning for the antibody motes: rows are PE levels 1-3.
+AntibodyStep D_antibody_80130BD4[] = {
+    { 0x0008, 0x0090, 0x0005, 0x0200, 0x0080, 0x0600, 0x0008 },
+    { 0x000C, 0x00C0, 0x0006, 0x0300, 0x0100, 0x0700, 0x0006 },
+    { 0x0010, 0x00F0, 0x0007, 0x0400, 0x0180, 0x0800, 0x0004 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_antibody_80130BD4` row.
+s32 D_antibody_80130C00[] = { 0xE0290001, 0xE02C0001, 0xE02F0001 };
+
 extern s32 Gp_LcgState;
 
 /// `gpf 1` / `rtps`. The `inline_c.h` macros of those names assemble to
@@ -43,6 +53,10 @@ void func_antibody_80130428(GsCOORDINATE2* arg0, s16 arg1, s16 arg2);
 /// the row's `field_2` cap it spawns the `0x800600AC` burst, latches
 /// `field_28` and moves to state 2, which shrinks `field_24` by 0x10 a frame
 /// and redraws at the capped radius until it drops below 0x11.
+/// Scratch for the mote ring's per-frame vertex work.
+/// lists an object in the linker script at its first subsegment, and this has
+s16 D_antibody_80130C0C[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
 void func_antibody_8012EF34(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/antibody/antibody.c
+++ b/src/pe/antibody/antibody.c
@@ -16,6 +16,10 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_antibody_8012EF30 = 57;
+
 /// Per-level tuning for the antibody motes: rows are PE levels 1-3.
 AntibodyStep D_antibody_80130BD4[] = {
     { 0x0008, 0x0090, 0x0005, 0x0200, 0x0080, 0x0600, 0x0008 },
@@ -589,5 +593,3 @@ void func_antibody_80130428(GsCOORDINATE2* arg0, s16 arg1, s16 arg2)
     }
     *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + sizeof(AntibodyArcScratch);
 }
-
-INCLUDE_RODATA("pe/nonmatchings/antibody/antibody", D_antibody_8012EF30);

--- a/src/pe/apobiosis/apobiosis.c
+++ b/src/pe/apobiosis/apobiosis.c
@@ -16,6 +16,16 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// Per-level tuning for the apobiosis pulse: rows are PE levels 1-3.
+ApobiosisStep D_apobiosis_80130B5C[] = {
+    { 0x0004, 0x0400, 0x00C0, 0x0280 },
+    { 0x0006, 0x0500, 0x0100, 0x0300 },
+    { 0x0008, 0x0600, 0x0140, 0x0400 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_apobiosis_80130B5C` row.
+s32 D_apobiosis_80130B74[] = { 0xE0170001, 0xE01A0001, 0xE01D0001 };
+
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")
 
 extern s8  D_80114C0B;
@@ -39,6 +49,11 @@ void func_apobiosis_80130630(GsCOORDINATE2* arg0, s16* arg1, s16 arg2, s16 arg3)
 /// a frame in state 3, two a frame in state 4 - and state 5 fades the last of
 /// the flash before releasing the work block. `Gp_SpawnPadLerp` rumbles at each
 /// state change, hardest on the widest row.
+/// Scratch for the pulse ring, plus the task handle it spawns.
+/// lists an object in the linker script at its first subsegment, and this has
+s16   D_apobiosis_80130B80[16] = { 0 };
+Task* D_apobiosis_80130BA0     = NULL;
+
 void func_apobiosis_8012EF4C(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/apobiosis/apobiosis_hdr.c
+++ b/src/pe/apobiosis/apobiosis_hdr.c
@@ -1,0 +1,9 @@
+#include "common.h"
+
+/// This overlay's id. Every package opens with one: a u16 in a u32 slot,
+/// distinct across all 448, with the families in contiguous blocks.
+///
+/// Its own unit because the rest of this overlay's leading rodata is a
+/// compiler-generated jump table that must start at the `rodata_head` cut;
+/// folding the id into that unit reorders both.
+const u32 D_apobiosis_8012EF30 = 53;

--- a/src/pe/combustion/combustion.c
+++ b/src/pe/combustion/combustion.c
@@ -13,6 +13,16 @@
 #include "main/tmd.h"
 #include "pe/combustion.h"
 
+/// Per-level tuning for the combustion flame: rows are PE levels 1-3.
+CombustionStep D_combustion_80130980[] = {
+    { 0x0060, 0x0120, 0x0007, 0x0015 },
+    { 0x0055, 0x0187, 0x0008, 0x0017 },
+    { 0x004C, 0x01F3, 0x0009, 0x0019 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_combustion_80130980` row.
+s32 D_combustion_80130998[] = { 0xE00C0002, 0xE00F0002, 0xE0120002 };
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 
@@ -28,6 +38,10 @@ void PeShared8012fb14(GsCOORDINATE2* arg0, s16 arg1, s16 arg2, s16 arg3);
 /// the yaw the ignition applied, and either state ends as soon as the player
 /// is dying (`Gp_StateC08.field_3`), the room is fading (`Gp_State1C`) or the
 /// row's `field_6` tick is reached.
+/// Live flame handle for the combustion effect.
+/// lists an object in the linker script at its first subsegment, and this has
+s32 D_combustion_801309A4 = 0;
+
 void func_combustion_8012EF34(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/combustion/combustion.c
+++ b/src/pe/combustion/combustion.c
@@ -13,6 +13,10 @@
 #include "main/tmd.h"
 #include "pe/combustion.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_combustion_8012EF30 = 49;
+
 /// Per-level tuning for the combustion flame: rows are PE levels 1-3.
 CombustionStep D_combustion_80130980[] = {
     { 0x0060, 0x0120, 0x0007, 0x0015 },
@@ -394,5 +398,3 @@ void func_combustion_8012F888(Task* arg0)
             return;
     }
 }
-
-INCLUDE_RODATA("pe/nonmatchings/combustion/combustion", D_combustion_8012EF30);

--- a/src/pe/combustion/combustion.c
+++ b/src/pe/combustion/combustion.c
@@ -16,6 +16,8 @@
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 
+void PeShared8012fb14(GsCOORDINATE2* arg0, s16 arg1, s16 arg2, s16 arg3);
+
 /// `rtps`: project V0 through the loaded rotation and translation matrices.
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")
 
@@ -276,6 +278,107 @@ void func_combustion_8012F5EC(GsCOORDINATE2* arg0, s16 arg1, s16 arg2)
     *scratch = (u8*)*scratch + 0x18;
 }
 
-INCLUDE_ASM("pe/nonmatchings/combustion/combustion", func_combustion_8012F888);
+/// One trailing ember shed by a `func_combustion_8012F2BC` flame. State 0 rolls
+/// the kind from `Gp_StateC08.field_0 % 10 - 1` into `field_2A`, two
+/// `Gp_LcgState` draws into the spin `field_24` and the per-frame rise
+/// `field_12` (`-(rand & 0xFF) - kind * 64`, so bigger embers climb faster),
+/// sizes the sprite as `kind * 0x100 + 0x300` in `field_26`, and enters
+/// `spawnArg1 + 1` - or one state later on a coin flip when `kind >= 2`. Every
+/// later state lifts the coordinate by `field_12` and redraws: state 1 steps
+/// `field_20` every other frame and draws the shared `PeShared8012fb14` flame
+/// on the odd frames, state 2 draws `func_combustion_8012FF0C` and state 3 the
+/// small `func_combustion_8012F5EC`, each releasing the ember after eight (six
+/// for state 3) frames.
+void func_combustion_8012F888(Task* arg0)
+{
+    GpEffWork*     mem;
+    GsCOORDINATE2* coord;
+    s32            rng;
+    s32            rng2;
+    s32            y;
+    s16            step;
+    s16            kind;
+    s16            frame;
+    s32            state;
+    s32            tmp;
+    s32            hi;
+    s32            tmp2;
+
+    mem           = arg0->spawnArg2;
+    coord         = ((TmdObject*)arg0->extra)->field_8;
+    mem->field_22 = (u16)mem->field_22 + 1;
+    state         = arg0->state;
+    switch (state) {
+        case 0:
+            kind          = (Gp_StateC08.field_0 % 10U) - 1;
+            rng           = Gp_LcgState * 5 + 0x71357911;
+            rng2          = rng * 5 + 0x71357911;
+            mem->field_24 = ((u32)rng2 >> 16) & 0xFFF;
+            hi            = ((u32)rng >> 16) & 0xFF;
+            mem->field_2A = kind;
+            /* The global store between the `field_2A` store and its reload keeps
+             * GCC from forwarding `kind` into the `lh`. */
+            Gp_LcgState   = rng;
+            tmp           = mem->field_2A;
+            mem->field_12 = -hi - (tmp << 6);
+            Gp_LcgState   = rng2;
+            arg0->state   = arg0->spawnArg1 + 1;
+            tmp2          = mem->field_2A;
+            mem->field_26 = (tmp2 << 8) + 0x300;
+            if (mem->field_2A >= 2) {
+                Gp_LcgState  = rng2 * 5 + 0x71357911;
+                arg0->state += ((u32)Gp_LcgState >> 16) & 1;
+            }
+            /* fallthrough */
+        case 1:
+            step              = mem->field_12;
+            y                 = coord->coord.t[1] + step;
+            coord->flg        = 0;
+            coord->coord.t[1] = y;
+            Gp_UpdateCoord(coord);
+            if (!((u16)mem->field_22 & 1)) {
+                mem->field_20 = (u16)mem->field_20 + 1;
+            }
+            frame = mem->field_20;
+            if (frame < 8) {
+                if ((u16)mem->field_22 & 1) {
+                    PeShared8012fb14(coord, frame, mem->field_26, mem->field_24);
+                    return;
+                }
+            } else {
+                Gp_ReleaseState1CMem(mem, arg0);
+                return;
+            }
+            break;
+        case 2:
+            step              = mem->field_12;
+            y                 = coord->coord.t[1] + step;
+            coord->flg        = 0;
+            coord->coord.t[1] = y;
+            Gp_UpdateCoord(coord);
+            frame         = (u16)mem->field_20 + 1;
+            mem->field_20 = frame;
+            if (frame < 8) {
+                func_combustion_8012FF0C(coord, frame, mem->field_26);
+                return;
+            }
+            Gp_ReleaseState1CMem(mem, arg0);
+            return;
+        case 3:
+            step              = mem->field_12;
+            y                 = coord->coord.t[1] + step;
+            coord->flg        = 0;
+            coord->coord.t[1] = y;
+            Gp_UpdateCoord(coord);
+            frame         = (u16)mem->field_20 + 1;
+            mem->field_20 = frame;
+            if (frame < 6) {
+                func_combustion_8012F5EC(coord, frame, mem->field_26);
+                return;
+            }
+            Gp_ReleaseState1CMem(mem, arg0);
+            return;
+    }
+}
 
 INCLUDE_RODATA("pe/nonmatchings/combustion/combustion", D_combustion_8012EF30);

--- a/src/pe/energyball/energyball.c
+++ b/src/pe/energyball/energyball.c
@@ -15,6 +15,23 @@
 #include "main/tmd.h"
 #include "pe/energyball.h"
 
+/// The `SndEvt_EnqueueType6` ids: three charge cues then three release cues.
+s32 D_energyball_8013117C[] = {
+    0xE02B0002,
+    0xE02E0002,
+    0xE0310002,
+    0xE02B0001,
+    0xE02E0001,
+    0xE0310001,
+};
+
+/// Per-level radius/step pairs for the ball: rows are PE levels 1-3.
+EnergyBallStep D_energyball_80131194[] = {
+    { 0x0400, 0x0040 },
+    { 0x0480, 0x0048 },
+    { 0x0500, 0x0050 },
+};
+
 extern s32 D_80115724;
 extern s32 Gp_LcgState;
 
@@ -30,6 +47,10 @@ extern s32 Gp_LcgState;
 /// table and spawns one ball per charge level, fanning them out by 0x555 of
 /// yaw each while `D_80115724` (the number of balls already in flight) allows
 /// it. Every later frame just releases the work block.
+/// Scratch for the ball's per-frame vertex work.
+/// lists an object in the linker script at its first subsegment, and this has
+s16 D_energyball_801311A0[16] = { 0 };
+
 void func_energyball_8012EF48(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/energyball/energyball.c
+++ b/src/pe/energyball/energyball.c
@@ -2,12 +2,14 @@
 
 #include <psyq/inline_c.h>
 
+#include "gameplay/3A34.h"
 #include "gameplay/3CD8.h"
 #include "gameplay/3FB8.h"
 #include "gameplay/gameplay.h"
 #include "main/display.h"
 #include "main/gfx.h"
 #include "main/mem.h"
+#include "main/session.h"
 #include "main/sound.h"
 #include "main/task.h"
 #include "main/tmd.h"
@@ -16,11 +18,12 @@
 extern s32 D_80115724;
 extern s32 Gp_LcgState;
 
-/// `rtps` / `rtpt` / `mvmva 1,0,0,3,0`. The `inline_c.h` macros of those names
+/// `rtps` / `rtpt` / `mvmva 1,0,0,3,0` / `gpf 12`. The `inline_c.h` macros of those names
 /// assemble to different words, so spell the instructions out.
-#define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")
-#define gte_rtpt_real() __asm__ volatile("nop; nop; .word 0x4A280030")
-#define gte_rtv0_real() __asm__ volatile("nop; nop; .word 0x4A486012")
+#define gte_rtps_real()  __asm__ volatile("nop; nop; .word 0x4A180001")
+#define gte_rtpt_real()  __asm__ volatile("nop; nop; .word 0x4A280030")
+#define gte_rtv0_real()  __asm__ volatile("nop; nop; .word 0x4A486012")
+#define gte_gpf12_real() __asm__ volatile("nop; nop; .word 0x4B98003D")
 
 /// Fires the energy ball: on the first frame it picks the charge level from the
 /// combo counter, plays the matching loop sound, refills the surface-jitter
@@ -71,9 +74,314 @@ void func_energyball_8012EF48(Task* arg0)
     }
 }
 
-INCLUDE_RODATA("pe/nonmatchings/energyball/energyball", D_energyball_8012EF30);
+/// One ball of the energy ball cast; `spawnArg1` picks the `Gp_RoomCoords`
+/// slot it owns and `spawnArg2` the `GpEffWork` block. While the room is
+/// fading (`Gp_State1C->field_E`) it only redraws, and drops the ball once the
+/// fade passes 4. Otherwise it walks `Task::state`: 0 allocates the
+/// `EnergyBallWork` collision block, picks the charge row of
+/// `D_energyball_80131194` from the combo counter and seeds a random spin
+/// `field_28`; 1 grows the ball by the row's `field_2` per frame until it
+/// reaches `field_0`, then links it on list 1 with a random direction; 2
+/// flies it, re-aiming at the player every eighth frame and nudging each
+/// velocity component by 0x10 on odd frames, bursting into three 0x600F9
+/// effects on a hit (`Gp_CountRec18Hi`) or unlinking when the room's
+/// `field_16` drops; 3 and 4 fade the burst out, growing to twice the row's
+/// size or shrinking below one step. Cancel (`Gp_StateC08.field_3 == -2` or
+/// the fade at 4 or more) anywhere but combo 0x2B lets the ball go: the last
+/// ball in flight (`D_80115724`) queues the row's stop sound.
+void func_energyball_8012F180(Task* arg0)
+{
+    GpEffWork*      mem;
+    GsCOORDINATE2*  coord;
+    EnergyBallWork* work;
+    GpCoord64*      slot;
+    GsCOORDINATE2*  sc;
+    GpCoordTail*    tail;
+    GsCOORDINATE2   ground;
+    VECTOR          vec;
+    GsCOORDINATE2*  player;
+    GpEffWork*      spawned;
+    SVECTOR*        dir;
+    u16             r;
+    s32*            snd;
+    s16             fade;
+    s32             cur;
 
-INCLUDE_ASM("pe/nonmatchings/energyball/energyball", func_energyball_8012F180);
+    slot  = &Gp_RoomCoords[arg0->spawnArg1 + 4];
+    sc    = &slot->coord;
+    tail  = (GpCoordTail*)sc;
+    coord = ((TmdObject*)arg0->extra)->field_8;
+    fade  = Gp_State1C->field_E;
+    work  = (EnergyBallWork*)arg0->idMap;
+    mem   = arg0->spawnArg2;
+    if (fade != 0) {
+        if (fade >= 4) {
+            if (D_80115724 > 0) {
+                D_80115724 -= 1;
+                if (D_80115724 == 0) {
+                    SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                }
+            }
+            if (arg0->state != 0) {
+            unlink:
+                Gp_UnlinkObj(&work->obj);
+            }
+            goto release;
+        }
+        Gp_UpdateCoord(coord);
+        func_energyball_8013035C(coord, mem->field_22, mem->field_26, mem->field_28);
+        func_energyball_8012FFD0(coord, mem->field_26, (s16)(u16)mem->field_24 >> 2);
+        if ((arg0->state < 3) && (Gp_State1C->field_6 != 0) &&
+            (Gp_TraceGroundCoord(coord, &ground) == 1)) {
+            func_energyball_801307D4(&ground, mem->field_26);
+        }
+        return;
+    }
+
+    mem->field_22 = (u16)mem->field_22 + 1;
+    switch (arg0->state) {
+        case 0:
+            work = Mem_Calloc(0x38, 0);
+            if (work == NULL) {
+                mem->field_22 = 0;
+                return;
+            }
+            arg0->idMap   = (TaskIdMap*)work;
+            mem->field_20 = (Gp_StateC08.field_0 % 10) - 1;
+            mem->field_10 = 0;
+            Gp_LcgState   = Gp_LcgState * 5 + 0x71357911;
+            mem->field_12 = -(u16)D_energyball_80131194[mem->field_20].field_2;
+            mem->field_14 = 0;
+            mem->field_26 = 0;
+            mem->field_28 = ((u32)Gp_LcgState >> 16) & 0xFFF;
+            D_80115724   += 1;
+            mem->field_24 = 0xC0;
+            mem->field_2A = 0x20;
+            arg0->state   = 1;
+            /* fallthrough */
+        case 1:
+            if (mem->field_26 < D_energyball_80131194[mem->field_20].field_0) {
+                mem->field_26      = (u16)mem->field_26 + (u16)D_energyball_80131194[mem->field_20].field_2;
+                coord->coord.t[0] += mem->field_10;
+                coord->coord.t[1] += mem->field_12;
+                coord->coord.t[2] += mem->field_14;
+                coord->flg         = 0;
+                Gp_UpdateCoord(coord);
+            } else {
+                Gp_UpdateCoord(coord);
+                arg0->idMap        = (TaskIdMap*)work;
+                work->obj.field_C  = &work->rec;
+                work->obj.field_8  = coord;
+                work->obj.field_18 = ((u16)(Gp_StateC08.field_0 / 100) - 1) * 9 +
+                                     ((u16)((u16)(Gp_StateC08.field_0 % 100) / 10) - 1) * 3 +
+                                     (u16)(Gp_StateC08.field_0 % 10) + 0x28000;
+                work->obj.field_1C = (s16)(u16)mem->field_26 >> 1;
+                work->obj.flags    = 1;
+                Gp_LinkObj(1, &work->obj);
+                dir               = (SVECTOR*)&mem->field_10;
+                work->rec.field_0 = 2;
+                work->obj.flags  |= 0x8000;
+                arg0->state       = 2;
+                Gp_LcgState       = Gp_LcgState * 5 + 0x71357911;
+                mem->field_10     = 0x800 - (((u32)Gp_LcgState >> 16) & 0xFFF);
+                Gp_LcgState       = Gp_LcgState * 5 + 0x71357911;
+                mem->field_12     = 0x800 - (((u32)Gp_LcgState >> 16) & 0xFFF);
+                Gp_LcgState       = Gp_LcgState * 5 + 0x71357911;
+                mem->field_14     = 0x800 - (((u32)Gp_LcgState >> 16) & 0xFFF);
+                VectorNormalSS(dir, dir);
+                gte_lddp((u16)mem->field_2A);
+                gte_ldsv(dir);
+                gte_gpf12_real();
+                gte_stsv(dir);
+                mem->field_18 = 0;
+                mem->field_1A = -(u16)D_energyball_80131194[mem->field_20].field_2;
+                mem->field_1C = 0;
+            }
+            slot->field_0  = 2;
+            tail->field_58 = 0x100;
+            tail->field_5C = 0x1000;
+            Gp_LcgState    = Gp_LcgState * 5 + 0x71357911;
+            r              = (((u32)Gp_LcgState >> 16) & 0x700) + 0x800;
+            tail->field_52 = r;
+            tail->field_50 = (u16)tail->field_52 >> 1;
+            tail->field_54 = tail->field_52 >> 1;
+            sc->coord.t[0] = coord->coord.t[0];
+            sc->coord.t[1] = coord->coord.t[1];
+            sc->coord.t[2] = coord->coord.t[2];
+            sc->flg        = 0;
+            func_energyball_8013035C(coord, mem->field_22, mem->field_26, mem->field_28);
+            func_energyball_8012FFD0(coord, mem->field_26, (s16)(u16)mem->field_24 >> 2);
+            if ((Gp_State1C->field_6 != 0) && (Gp_TraceGroundCoord(coord, &ground) == 1)) {
+                func_energyball_801307D4(&ground, mem->field_26);
+            }
+            coord->workm.t[1] += D_energyball_80131194[mem->field_20].field_2 * mem->field_22;
+            func_energyball_80130B54(coord, mem->field_26,
+                                     (D_energyball_80131194[mem->field_20].field_0 - mem->field_26) / 5);
+            coord->workm.t[1] -= D_energyball_80131194[mem->field_20].field_2 * mem->field_22;
+            if ((u16)(Gp_StateC08.field_0 / 10) != 0x2B) {
+                if ((Gp_StateC08.field_3 == -2) || (Gp_State1C->field_E >= 4)) {
+                    if (D_80115724 > 0) {
+                        D_80115724 -= 1;
+                        if (D_80115724 == 0) {
+                            SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                        }
+                    }
+                    goto unlink;
+                }
+            }
+            return;
+        case 2:
+            if (((u16)mem->field_22 & 7) == 0) {
+                player = &((TmdObject*)((Task*)Game_GetPtrSlot(3))->extra)->field_8[1];
+                vec.vx = player->workm.t[0] - coord->workm.t[0];
+                vec.vy = player->workm.t[1] - coord->workm.t[1];
+                vec.vz = player->workm.t[2] - coord->workm.t[2];
+                ApplyTransposeMatrixLV(&coord->workm, &vec, &vec);
+                mem->field_18 = vec.vx;
+                mem->field_1A = vec.vy;
+                mem->field_1C = vec.vz;
+                gte_SetRotMatrix(&coord->coord);
+                gte_ldv0(&mem->field_18);
+                gte_rtv0_real();
+                gte_stsv(&mem->field_18);
+                gte_lddp(mem->field_20 * 0x180 + 0xA00);
+                gte_ldsv(&mem->field_10);
+                gte_gpf12_real();
+                gte_stsv(&mem->field_10);
+            }
+            if ((u16)mem->field_22 & 1) {
+                cur           = mem->field_10;
+                mem->field_10 = (cur < mem->field_18) ? cur + 0x10 : cur - 0x10;
+                cur           = mem->field_12;
+                mem->field_12 = (cur < mem->field_1A) ? cur + 0x10 : cur - 0x10;
+                cur           = mem->field_14;
+                mem->field_14 = (cur < mem->field_1C) ? cur + 0x10 : cur - 0x10;
+            }
+            coord->coord.t[0] += mem->field_10;
+            coord->coord.t[1] += mem->field_12;
+            coord->coord.t[2] += mem->field_14;
+            coord->flg         = 0;
+            Gp_UpdateCoord(coord);
+            slot->field_0  = 2;
+            tail->field_58 = 0x100;
+            tail->field_5C = 0x1000;
+            Gp_LcgState    = Gp_LcgState * 5 + 0x71357911;
+            r              = (((u32)Gp_LcgState >> 16) & 0x700) + 0x800;
+            tail->field_52 = r;
+            tail->field_50 = (u16)tail->field_52 >> 1;
+            tail->field_54 = tail->field_52 >> 1;
+            sc->coord.t[0] = coord->coord.t[0];
+            sc->coord.t[1] = coord->coord.t[1];
+            sc->coord.t[2] = coord->coord.t[2];
+            sc->flg        = 0;
+            func_energyball_8013035C(coord, mem->field_22, mem->field_26, mem->field_28);
+            func_energyball_8012FFD0(coord, mem->field_26, (s16)(u16)mem->field_24 >> 2);
+            if (Gp_State1C->field_6 != 0) {
+                if (Gp_TraceGroundCoord(coord, &ground) == 1) {
+                    func_energyball_801307D4(&ground, mem->field_26);
+                }
+            }
+            if ((u16)(Gp_StateC08.field_0 / 10) != 0x2B) {
+                if ((Gp_StateC08.field_3 == -2) || (Gp_State1C->field_E >= 4)) {
+                    if (D_80115724 > 0) {
+                        D_80115724 -= 1;
+                        if (D_80115724 == 0) {
+                            SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                            SCHED_BARRIER();
+                        }
+                    }
+                    goto unlink;
+                }
+            }
+            if (Gp_CountRec18Hi(work->obj.field_C, 0x30000) != 0) {
+                spawned = Gp_SpawnEff(0x600F9, coord, 0, NULL);
+                if (spawned != NULL) {
+                    Task_Reparent(arg0, spawned->field_0);
+                }
+                spawned = Gp_SpawnEff(0x600F9, coord, 0x2AA, NULL);
+                if (spawned != NULL) {
+                    Task_Reparent(arg0, spawned->field_0);
+                }
+                spawned = Gp_SpawnEff(0x600F9, coord, 0x555, NULL);
+                if (spawned != NULL) {
+                    Task_Reparent(arg0, spawned->field_0);
+                }
+                snd = D_energyball_8013117C;
+                SndEvt_EnqueueType6(snd[mem->field_20 + 3], 0, 0);
+                Gp_UnlinkObj(&work->obj);
+                mem->field_26 = (u16)D_energyball_80131194[mem->field_20].field_0;
+                arg0->state   = 3;
+                return;
+            }
+            if (Gp_State1C->field_16 != 1) {
+                Gp_UnlinkObj(&work->obj);
+                arg0->state = 4;
+                return;
+            }
+            Gp_ClearRec18Occupied(&work->rec);
+            return;
+        case 3:
+            Gp_UpdateCoord(coord);
+            func_energyball_8013035C(coord, mem->field_22, mem->field_26, mem->field_28);
+            func_energyball_8012FFD0(coord, mem->field_26, (s16)(u16)mem->field_24 >> 2);
+            func_energyball_8012FFD0(coord, (u16)mem->field_26 * 2, (s16)(u16)mem->field_24 >> 2);
+            mem->field_26 = (u16)mem->field_26 + (u16)D_energyball_80131194[mem->field_20].field_2;
+            if (((u16)(Gp_StateC08.field_0 / 10) != 0x2B) &&
+                ((Gp_StateC08.field_3 == -2) || (Gp_State1C->field_E >= 4))) {
+                if (D_80115724 > 0) {
+                    D_80115724 -= 1;
+                    if (D_80115724 == 0) {
+                        SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                    }
+                }
+                Gp_ReleaseState1CMem(mem, arg0);
+                return;
+            }
+            if (D_energyball_80131194[mem->field_20].field_0 * 2 < mem->field_26) {
+                if (D_80115724 > 0) {
+                    D_80115724 -= 1;
+                    if (D_80115724 == 0) {
+                        SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                    }
+                }
+                Gp_ReleaseState1CMem(mem, arg0);
+                return;
+            }
+            return;
+        case 4:
+            Gp_UpdateCoord(coord);
+            func_energyball_8013035C(coord, mem->field_22, mem->field_26, mem->field_28);
+            func_energyball_8012FFD0(coord, mem->field_26, (s16)(u16)mem->field_24 >> 2);
+            func_energyball_8012FFD0(coord, (u16)mem->field_26 * 2, (s16)(u16)mem->field_24 >> 2);
+            mem->field_26 = (u16)mem->field_26 - (u16)D_energyball_80131194[mem->field_20].field_2;
+            if (((u16)(Gp_StateC08.field_0 / 10) != 0x2B) &&
+                ((Gp_StateC08.field_3 == -2) || (Gp_State1C->field_E >= 4))) {
+                if (D_80115724 > 0) {
+                    D_80115724 -= 1;
+                    if (D_80115724 == 0) {
+                        SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                    }
+                }
+                Gp_ReleaseState1CMem(mem, arg0);
+                return;
+            }
+            if (mem->field_26 < D_energyball_80131194[mem->field_20].field_2) {
+                if (D_80115724 > 0) {
+                    D_80115724 -= 1;
+                    if (D_80115724 == 0) {
+                        SndEvt_EnqueueType7(D_energyball_8013117C[mem->field_20], 1);
+                    }
+                }
+                Gp_ReleaseState1CMem(mem, arg0);
+                return;
+            }
+            return;
+        default:
+            return;
+    }
+release:
+    Gp_ReleaseState1CMem(mem, arg0);
+}
 
 /// Overlay copy of `Gp_DrawRing` with a flat tint: draws an eight-segment
 /// gouraud ring centred on `arg0`'s world position. The position is projected

--- a/src/pe/energyball/energyball.c
+++ b/src/pe/energyball/energyball.c
@@ -75,7 +75,84 @@ INCLUDE_RODATA("pe/nonmatchings/energyball/energyball", D_energyball_8012EF30);
 
 INCLUDE_ASM("pe/nonmatchings/energyball/energyball", func_energyball_8012F180);
 
-INCLUDE_ASM("pe/nonmatchings/energyball/energyball", func_energyball_8012FFD0);
+/// Overlay copy of `Gp_DrawRing` with a flat tint: draws an eight-segment
+/// gouraud ring centred on `arg0`'s world position. The position is projected
+/// through `GsWSMATRIX` by one `RTPS` and the ring is dropped when that sets a
+/// negative `gte_stflg`. `arg1` is the radius in world units (scaled by 64 and
+/// divided by the projected OTZ) and `arg2` the brightness: only the inner
+/// vertex of each `POLY_G4` is lit, `(arg2 / 2, arg2, arg2 / 2)`, so every
+/// wedge fades from green at the centre to black at the rim. Each wedge gets
+/// the semi-transparent tpage of `Gp_AddTpageShift` at its OTZ.
+void func_energyball_8012FFD0(GsCOORDINATE2* arg0, s16 arg1, s16 arg2)
+{
+    void**         scratch;
+    u8*            head;
+    GpRingScratch* block;
+    POLY_G4*       prim;
+    s32            ang;
+    register s32   ang2 asm("s1");
+    s16            color;
+    s32            half;
+    u16            vz;
+
+    scratch = (void**)G_SCRATCH_HEAD;
+    color   = arg2;
+    head    = *scratch;
+    USE_REG(head);
+    {
+        register u16 vx asm("v0");
+        vx                                      = *(u16*)&arg0->workm.t[0];
+        ((GpRingScratch*)(head - 0x18))->vec.vx = vx;
+    }
+    {
+        register u8* tmp asm("v0");
+        tmp   = head - 0x18;
+        block = (GpRingScratch*)tmp;
+    }
+    block->vec.vy = *(u16*)&arg0->workm.t[1];
+    vz            = *(u16*)&arg0->workm.t[2];
+    *scratch      = block;
+    block->vec.vz = vz;
+    gte_SetTransMatrix(&GsWSMATRIX);
+    gte_SetRotMatrix(&GsWSMATRIX);
+    gte_ldv0(&block->vec);
+    gte_rtps_real();
+    gte_stsxy(&((GpRingScratch*)(head - 0x18))->sx);
+    gte_stflg(&((GpRingScratch*)(head - 0x18))->flag);
+    if (block->flag >= 0) {
+        gte_stszotz(&((GpRingScratch*)(head - 0x18))->otz);
+        USE_REG(head);
+        block->otz++;
+        block->step = (arg1 * 64) / block->otz;
+        half        = arg2 >> 1;
+        ang         = 0;
+        do {
+            prim           = (POLY_G4*)Gpu_PrimCursor;
+            Gpu_PrimCursor = (DR_TPAGE*)(prim + 1);
+            setPolyG4(prim);
+            setRGB0(prim, 0, 0, 0);
+            setRGB1(prim, 0, 0, 0);
+            setRGB2(prim, half, color, half);
+            setRGB3(prim, 0, 0, 0);
+            prim->x0 = *(u16*)&block->sx + ((block->step * rsin(ang)) >> 12);
+            prim->y0 = *(u16*)&block->sy + ((block->step * rcos(ang)) >> 12);
+            ang2     = ang + 0x100;
+            prim->x1 = *(u16*)&block->sx + ((block->step * rsin(ang2)) >> 12);
+            prim->y1 = *(u16*)&block->sy + ((block->step * rcos(ang2)) >> 12);
+            prim->x2 = *(u16*)&block->sx;
+            prim->y2 = *(u16*)&block->sy;
+            ang2     = ang + 0x200;
+            prim->x3 = *(u16*)&block->sx + ((block->step * rsin(ang2)) >> 12);
+            prim->y3 = *(u16*)&block->sy + ((block->step * rcos(ang2)) >> 12);
+            ang      = ang2;
+            addPrim((u_long*)(((((u32)block->otz << Display_State.field_128) >> 2) & 0xFFC) +
+                              (s32)Gpu_CurrentOt),
+                    prim);
+            Gp_AddTpageShift((P_TAG*)prim, 1, block->otz);
+        } while (ang < 0x1000);
+    }
+    *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + 0x18;
+}
 
 /// Links one frame of the energy ball's core sprite at `arg0`'s world
 /// position. The position is projected through `GsWSMATRIX` by a single `RTPS`

--- a/src/pe/energyball/energyball_hdr.c
+++ b/src/pe/energyball/energyball_hdr.c
@@ -1,0 +1,9 @@
+#include "common.h"
+
+/// This overlay's id. Every package opens with one: a u16 in a u32 slot,
+/// distinct across all 448, with the families in contiguous blocks.
+///
+/// Its own unit because the rest of this overlay's leading rodata is a
+/// compiler-generated jump table that must start at the `rodata_head` cut;
+/// folding the id into that unit reorders both.
+const u32 D_energyball_8012EF30 = 59;

--- a/src/pe/energyshot/energyshot.c
+++ b/src/pe/energyshot/energyshot.c
@@ -9,6 +9,18 @@
 #include "main/tmd.h"
 #include "pe/energyshot.h"
 
+/// Per-level tuning for the energy shot: rows are PE levels 1-3. The last
+/// row's `field_6` was split into its own symbol by splat because the code
+/// reads it directly; it is `D_energyshot_801300E4[2].field_6` here.
+EnergyShotScale D_energyshot_801300E4[] = {
+    { 0x0008, 0x0090, 0x0005, 0x0400 },
+    { 0x000C, 0x00C0, 0x0006, 0x0500 },
+    { 0x0010, 0x00F0, 0x0007, 0x0600 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_energyshot_801300E4` row.
+s32 D_energyshot_801300FC[] = { 0xE02A0001, 0xE02D0001, 0xE0300001 };
+
 extern s32 Gp_LcgState;
 
 void func_energyshot_8012FA50(GsCOORDINATE2* arg0, s16 arg1, s32 arg2, u8* arg3);
@@ -23,6 +35,11 @@ void PeShared801305c0(GsCOORDINATE2* arg0, s32 arg1, s32 arg2, u8* rgb);
 /// brightness / radius, draws three rings plus `field_0` wedges and the beam,
 /// and parents a `0x600F4` spark; once brightness exceeds the row cap it
 /// advances to state 2, which shrinks brightness until it drops below 0x11.
+/// Two scratch rings the shot walks while in flight.
+/// lists an object in the linker script at its first subsegment, and this has
+s16 D_energyshot_80130108[16] = { 0 };
+s16 D_energyshot_80130128[16] = { 0 };
+
 void func_energyshot_8012EF34(Task* arg0)
 {
     GpEffWork*     mem;
@@ -143,7 +160,7 @@ void func_energyshot_8012EF34(Task* arg0)
                 if (mem->field_20 != 0) {
                     if (mem->field_20 == 2) {
                         func_energyshot_8012FA50(coord, (s16)(mem->field_24 * 8),
-                                                 (s32)(D_energyshot_801300FA << 16) >> 17, rgb);
+                                                 (s32)((u16)D_energyshot_801300E4[2].field_6 << 16) >> 17, rgb);
                     }
                     func_energyshot_8012FA50(
                         coord, (s16)(mem->field_24 * 4),

--- a/src/pe/energyshot/energyshot.c
+++ b/src/pe/energyshot/energyshot.c
@@ -9,6 +9,10 @@
 #include "main/tmd.h"
 #include "pe/energyshot.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_energyshot_8012EF30 = 58;
+
 /// Per-level tuning for the energy shot: rows are PE levels 1-3. The last
 /// row's `field_6` was split into its own symbol by splat because the code
 /// reads it directly; it is `D_energyshot_801300E4[2].field_6` here.
@@ -242,5 +246,3 @@ void func_energyshot_8012EF34(Task* arg0)
 release:
     Gp_ReleaseState1CMem(mem, arg0);
 }
-
-INCLUDE_RODATA("pe/nonmatchings/energyshot/energyshot", D_energyshot_8012EF30);

--- a/src/pe/flare/flare.c
+++ b/src/pe/flare/flare.c
@@ -13,6 +13,10 @@
 #include "main/tmd.h"
 #include "pe/flare.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_flare_8012EF30 = 61;
+
 extern s32 Gp_LcgState;
 
 /// `mvmva 1, 0, 0, 3, 0`: rotate V0 by the rotation matrix, no translation.
@@ -195,5 +199,3 @@ void func_flare_8012F304(GsCOORDINATE2* arg0, u16 arg1, s16 arg2, s16 arg3)
     }
     *scratch = (u8*)*scratch + 0x1C;
 }
-
-INCLUDE_RODATA("pe/nonmatchings/flare/flare", D_flare_8012EF30);

--- a/src/pe/healing/healing.c
+++ b/src/pe/healing/healing.c
@@ -10,6 +10,18 @@
 #include "main/tmd.h"
 #include "pe/healing.h"
 
+/// Per-level tuning for the healing aura: rows are PE levels 1-3, selected by
+/// `field_20`. `field_2` is the brightness ceiling, `field_4` the per-tick
+/// spin, `field_6` the radius the ring grows to before the effect ends.
+HealingScale D_healing_8012FC1C[] = {
+    { 0x0008, 0x0080, 0x0040, 0x0400 },
+    { 0x000C, 0x00B0, 0x0048, 0x0500 },
+    { 0x0010, 0x00E0, 0x0050, 0x0600 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_healing_8012FC1C` row.
+s32 D_healing_8012FC34[] = { 0xE0200001, 0xE0230001, 0xE0260001 };
+
 extern s32 Gp_LcgState;
 
 /// Healing PE ring. Cancel (`Gp_StateC08.field_3 == -2` or

--- a/src/pe/healing/healing.c
+++ b/src/pe/healing/healing.c
@@ -10,6 +10,10 @@
 #include "main/tmd.h"
 #include "pe/healing.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_healing_8012EF30 = 55;
+
 /// Per-level tuning for the healing aura: rows are PE levels 1-3, selected by
 /// `field_20`. `field_2` is the brightness ceiling, `field_4` the per-tick
 /// spin, `field_6` the radius the ring grows to before the effect ends.
@@ -182,5 +186,3 @@ void func_healing_8012EF34(Task* arg0)
             return;
     }
 }
-
-INCLUDE_RODATA("pe/nonmatchings/healing/healing", D_healing_8012EF30);

--- a/src/pe/inferno/inferno.c
+++ b/src/pe/inferno/inferno.c
@@ -186,7 +186,8 @@ void func_inferno_8012F3EC(s16 arg0)
     Gp_AddTpageShift((P_TAG*)p, 1, z);
 }
 
-INCLUDE_RODATA("pe/nonmatchings/inferno/inferno", D_inferno_8012EF68);
+/// Trailing zero word in this unit's rodata.
+const u32 D_inferno_8012EF68 = 0;
 
 /// Companion inferno-cast task: state 0 allocates a 12-byte `InfernoIdMap`
 /// of LCG jitter, scales `GpEffWork::field_18` by 0x80 (`gte_gpf12`) and

--- a/src/pe/inferno/inferno.c
+++ b/src/pe/inferno/inferno.c
@@ -14,6 +14,15 @@
 #include "main/tmd.h"
 #include "pe/inferno.h"
 
+/// The two fan shapes the inferno wall sweeps through.
+InfernoFanParam D_inferno_801304E4[] = {
+    { 0x0100, 0x0800, 0x0200 },
+    { 0x0200, 0x0600, 0x0300 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each inferno stage.
+s32 D_inferno_801304F0[] = { 0xE0100001, 0xE0130001, 0xE00D0001 };
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 

--- a/src/pe/inferno/inferno_hdr.c
+++ b/src/pe/inferno/inferno_hdr.c
@@ -1,0 +1,9 @@
+#include "common.h"
+
+/// This overlay's id. Every package opens with one: a u16 in a u32 slot,
+/// distinct across all 448, with the families in contiguous blocks.
+///
+/// Its own unit because the rest of this overlay's leading rodata is a
+/// compiler-generated jump table that must start at the `rodata_head` cut;
+/// folding the id into that unit reorders both.
+const u32 D_inferno_8012EF30 = 50;

--- a/src/pe/lifedrain/lifedrain.c
+++ b/src/pe/lifedrain/lifedrain.c
@@ -15,6 +15,23 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// Per-level tuning for the life drain: rows are PE levels 1-3.
+LifeDrainScale D_lifedrain_80130AB4[] = {
+    { 0x0008, 0x0080, 0x0100, 0x0400, 0x0040 },
+    { 0x000C, 0x00B0, 0x0200, 0x0500, 0x0048 },
+    { 0x0010, 0x00E0, 0x0300, 0x0600, 0x0050 },
+};
+
+/// The `SndEvt_EnqueueType6` ids: three drain cues then three release cues.
+s32 D_lifedrain_80130AD4[] = {
+    0xE0210001,
+    0xE0240001,
+    0xE0270001,
+    0xE0210002,
+    0xE0240002,
+    0xE0270002,
+};
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 
@@ -50,6 +67,11 @@ void PeShared801305c0(GsCOORDINATE2* arg0, s32 arg1, s32 arg2, u8* rgb);
 /// `field_26` radius. Once `field_26` passes the row's `unk6` it moves to state
 /// 3, which shrinks `field_24` by 0x10 a frame and redraws the same funnel
 /// until it drops below 0x11, then releases through state 4.
+/// Scratch for the drain ribbon, plus the task handle it spawns.
+/// lists an object in the linker script at its first subsegment, and this has
+s16           D_lifedrain_80130AEC[16] = { 0 };
+struct _Task* D_lifedrain_80130B0C     = NULL;
+
 void func_lifedrain_8012EF48(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/lifedrain/lifedrain_hdr.c
+++ b/src/pe/lifedrain/lifedrain_hdr.c
@@ -1,0 +1,9 @@
+#include "common.h"
+
+/// This overlay's id. Every package opens with one: a u16 in a u32 slot,
+/// distinct across all 448, with the families in contiguous blocks.
+///
+/// Its own unit because the rest of this overlay's leading rodata is a
+/// compiler-generated jump table that must start at the `rodata_head` cut;
+/// folding the id into that unit reorders both.
+const u32 D_lifedrain_8012EF30 = 56;

--- a/src/pe/metabolism/metabolism.c
+++ b/src/pe/metabolism/metabolism.c
@@ -14,6 +14,10 @@
 #include "main/tmd.h"
 #include "pe/metabolism.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_metabolism_8012EF30 = 54;
+
 /// Per-level tuning for the metabolism drain: rows are PE levels 1-3.
 MetabolismStep D_metabolism_8012FB54[] = {
     { 0x0008, 0x0080, 0x0020, 0x0400 },
@@ -362,5 +366,3 @@ void func_metabolism_8012F840(GsCOORDINATE2* arg0, s32 arg1, s32 arg2, s32 arg3)
     }
     *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + 0x18;
 }
-
-INCLUDE_RODATA("pe/nonmatchings/metabolism/metabolism", D_metabolism_8012EF30);

--- a/src/pe/metabolism/metabolism.c
+++ b/src/pe/metabolism/metabolism.c
@@ -14,6 +14,19 @@
 #include "main/tmd.h"
 #include "pe/metabolism.h"
 
+/// Per-level tuning for the metabolism drain: rows are PE levels 1-3.
+MetabolismStep D_metabolism_8012FB54[] = {
+    { 0x0008, 0x0080, 0x0020, 0x0400 },
+    { 0x000C, 0x00B0, 0x0030, 0x0500 },
+    { 0x0010, 0x00E0, 0x0040, 0x0600 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_metabolism_8012FB54` row.
+s32 D_metabolism_8012FB6C[] = { 0xE01F0001, 0xE0220001, 0xE0250001 };
+
+/// Scratch for the drain ring (was its own _work unit).
+s16 D_metabolism_8012FB78[16] = { 0 };
+
 /// `rtps`. The `inline_c.h` macro of that name assembles to a different word,
 /// so spell the instruction out.
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")

--- a/src/pe/necrosis/necrosis.c
+++ b/src/pe/necrosis/necrosis.c
@@ -13,6 +13,18 @@
 #include "main/tmd.h"
 #include "pe/necrosis.h"
 
+/// Per-level tuning for the necrosis burst: rows are PE levels 1-3, selected
+/// by `field_20`. `field_0` is the `Gp_SpawnEff` draw parameter; `field_2` is
+/// the last spawn-loop tick, and `field_2 + 0xC` the pad-rumble duration.
+NecrosisStep D_necrosis_801306BC[] = {
+    { 0x03C0, 0x000A },
+    { 0x0480, 0x000F },
+    { 0x0540, 0x0014 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_necrosis_801306BC` row.
+s32 D_necrosis_801306C8[] = { 0xE0150001, 0xE0180001, 0xE01B0001 };
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 

--- a/src/pe/necrosis/necrosis.c
+++ b/src/pe/necrosis/necrosis.c
@@ -13,6 +13,10 @@
 #include "main/tmd.h"
 #include "pe/necrosis.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_necrosis_8012EF30 = 51;
+
 /// Per-level tuning for the necrosis burst: rows are PE levels 1-3, selected
 /// by `field_20`. `field_0` is the `Gp_SpawnEff` draw parameter; `field_2` is
 /// the last spawn-loop tick, and `field_2 + 0xC` the pad-rumble duration.
@@ -548,5 +552,3 @@ void func_necrosis_80130288(GsCOORDINATE2* arg0, s16 arg1, s16 arg2, s16 arg3)
     }
     *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + 0x1C;
 }
-
-INCLUDE_RODATA("pe/nonmatchings/necrosis/necrosis", D_necrosis_8012EF30);

--- a/src/pe/ofuda/ofuda.c
+++ b/src/pe/ofuda/ofuda.c
@@ -8,6 +8,10 @@
 #include "main/task.h"
 #include "main/tmd.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_ofuda_8012EF30 = 60;
+
 /// Ofuda PE flash. `Task::spawnArg2` is the `GpEffWork` block (`field_24`
 /// brightness, `field_26` ring radius, `field_2A` per-frame step);
 /// `Task::extra` reaches the coordinate. Cancel (`Gp_StateC08.field_3 == -2`
@@ -112,5 +116,3 @@ void func_ofuda_8012EF34(Task* arg0)
 kill:
     Gp_ReleaseState1CMem(mem, arg0);
 }
-
-INCLUDE_RODATA("pe/nonmatchings/ofuda/ofuda", D_ofuda_8012EF30);

--- a/src/pe/pepper_spray/pepper_spray.c
+++ b/src/pe/pepper_spray/pepper_spray.c
@@ -33,6 +33,10 @@ extern s32 Gp_LcgState;
 /// screen at the current brightness and draws the six cone quads. The effect
 /// ends after nine frames, or immediately if the player is dying
 /// (`D_80114C0B`) or the room is fading (`Gp_State1C`).
+/// Scratch the nozzle spray walks while the cloud is alive.
+/// lists an object in the linker script at its first subsegment, and this has
+s16 D_pepper_spray_8012FB9C[6] = { 0, 0, 0, 0, 0, 0 };
+
 void func_pepper_spray_8012EF34(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/pepper_spray/pepper_spray.c
+++ b/src/pe/pepper_spray/pepper_spray.c
@@ -16,6 +16,10 @@
 #include "main/tmd.h"
 #include "pe/pepper_spray.h"
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_pepper_spray_8012EF30 = 62;
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 
@@ -269,5 +273,3 @@ void func_pepper_spray_8012F634(GsCOORDINATE2* arg0, s16 arg1, s16 arg2)
        slots. A live `scratch` pointer would keep the address in `$fp`. */
     *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + sizeof(PepperSprayScratch);
 }
-
-INCLUDE_RODATA("pe/nonmatchings/pepper_spray/pepper_spray", D_pepper_spray_8012EF30);

--- a/src/pe/plasma/plasma.c
+++ b/src/pe/plasma/plasma.c
@@ -16,6 +16,10 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// This overlay's id. Every package opens with one: a u16 in a u32
+/// slot, distinct across all 448, with the families in contiguous blocks.
+const u32 D_plasma_8012EF30 = 52;
+
 /// Per-level geometry for the plasma ring: rows are PE levels 1-3. `rInner` is
 /// the inner radius, `yOff` the height above the caster, `rExtra` how far the
 /// ring grows before it breaks up.
@@ -452,5 +456,3 @@ void func_plasma_8012FB10(GsCOORDINATE2* arg0, s32 arg1, s32 arg2, u8* rgb)
     }
     *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + 0x1C;
 }
-
-INCLUDE_RODATA("pe/nonmatchings/plasma/plasma", D_plasma_8012EF30);

--- a/src/pe/plasma/plasma.c
+++ b/src/pe/plasma/plasma.c
@@ -17,10 +17,10 @@
 #include <psyq/libgte.h>
 
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")
+#define gte_rtpt_real() __asm__ volatile("nop; nop; .word 0x4A280030")
+#define gte_rtv0_real() __asm__ volatile("nop; nop; .word 0x4A486012")
 
 extern s32 Gp_LcgState;
-
-void func_plasma_8012F568(GpEffWork* arg0, GsCOORDINATE2* arg1, s32 arg2);
 
 /// Plasma PE ring. `Task::spawnArg2` is the `GpEffWork` block (`field_24`
 /// brightness, `field_20` combo index, `field_22` tick / inner radius);
@@ -249,7 +249,97 @@ release:
     Gp_ReleaseState1CMem(mem, arg0);
 }
 
-INCLUDE_ASM("pe/nonmatchings/plasma/plasma", func_plasma_8012F568);
+void func_plasma_8012F568(GpEffWork* arg0, GsCOORDINATE2* arg1, s32 arg2)
+{
+    void**           scratch;
+    u8*              head;
+    GpBandScratch*   block;
+    SVECTOR*         op;
+    POLY_FT4*        prim;
+    PlasmaRingScale* row;
+    s32              i;
+    s32              next;
+    s32              ang;
+    s32              u;
+    s16              idx;
+    s16              r0;
+    s16              r1;
+    u16              y;
+    u16              f28;
+
+    row      = &D_plasma_8012FF34[arg2];
+    f28      = (u16)arg0->field_28;
+    r1       = (u16)arg0->field_26;
+    y        = f28 + (u16)row->yOff;
+    r1      += (u16)row->rInner;
+    r0       = r1 + (u16)arg0->field_2A + (u16)row->rExtra;
+    scratch  = (void**)G_SCRATCH_HEAD;
+    head     = (u8*)*scratch;
+    *scratch = head - 0x118;
+    block    = (GpBandScratch*)(head - 0x118);
+    gte_SetTransMatrix(&GsWSMATRIX);
+    for (i = 0; i < 16; i++) {
+        ang                = i << 8;
+        block->inner[i].vx = (rsin(ang) * r0) >> 12;
+        block->inner[i].vy = -y;
+        block->inner[i].vz = (rcos(ang) * r0) >> 12;
+        gte_SetRotMatrix(&arg1->workm);
+        gte_ldv0(&block->inner[i]);
+        gte_rtv0_real();
+        gte_stsv(&block->inner[i]);
+        block->inner[i].vx = *(u16*)&block->inner[i].vx + *(u16*)&arg1->workm.t[0];
+        block->inner[i].vy = *(u16*)&block->inner[i].vy + *(u16*)&arg1->workm.t[1];
+        block->inner[i].vz = *(u16*)&block->inner[i].vz + *(u16*)&arg1->workm.t[2];
+        block->outer[i].vx = (rsin(ang) * r1) >> 12;
+        op                 = &block->inner[i] + 16;
+        op->vy             = 0;
+        op->vz             = (rcos(ang) * r1) >> 12;
+        gte_SetRotMatrix(&arg1->workm);
+        gte_ldv0(&block->outer[i]);
+        gte_rtv0_real();
+        gte_stsv(&block->outer[i]);
+        block->outer[i].vx = *(u16*)&block->outer[i].vx + *(u16*)&arg1->workm.t[0];
+        op->vy             = *(u16*)&op->vy + *(u16*)&arg1->workm.t[1];
+        op->vz             = *(u16*)&op->vz + *(u16*)&arg1->workm.t[2];
+    }
+    gte_SetRotMatrix(&GsWSMATRIX);
+    for (i = 0; i < 16; i++) {
+        gte_ldv0(&block->inner[i]);
+        gte_rtps_real();
+        idx = ((&D_plasma_8012FF54.a + i)[arg2 * 16] + arg0->field_22) % 6;
+        gte_stsxy(&block->sxy0);
+        next = (i + 1) & 0xF;
+        gte_ldv3(&block->inner[next], &block->outer[i], &block->outer[next]);
+        gte_rtpt_real();
+        gte_stsxy3(&block->sxy1, &block->sxy2, &block->sxy3);
+        gte_stflg(&block->flag);
+        if (block->flag >= 0) {
+            gte_stszotz(&block->otz);
+            block->otz++;
+            prim           = (POLY_FT4*)Gpu_PrimCursor;
+            Gpu_PrimCursor = (DR_TPAGE*)(prim + 1);
+            setPolyFT4(prim);
+            setRGB0(prim, *(u8*)&arg0->field_24, *(u8*)&arg0->field_24, *(u8*)&arg0->field_24);
+            setSemiTrans(prim, 1);
+            prim->tpage = 0x2A;
+            prim->clut  = 0x42C1;
+            u           = idx * 0x28;
+            setUV4(prim, u, 0x60, u + 0x27, 0x60, u, 0x87, u + 0x27, 0x87);
+            prim->x0 = *(u16*)&block->sxy0.vx;
+            prim->y0 = *(u16*)&block->sxy0.vy;
+            prim->x1 = *(u16*)&block->sxy1.vx;
+            prim->y1 = *(u16*)&block->sxy1.vy;
+            prim->x2 = *(u16*)&block->sxy2.vx;
+            prim->y2 = *(u16*)&block->sxy2.vy;
+            prim->x3 = *(u16*)&block->sxy3.vx;
+            prim->y3 = *(u16*)&block->sxy3.vy;
+            addPrim((u_long*)(((((u32)block->otz << Display_State.field_128) >> 2) & 0xFFC) +
+                              (s32)Gpu_CurrentOt),
+                    prim);
+        }
+    }
+    *(void**)G_SCRATCH_HEAD = (u8*)*(void**)G_SCRATCH_HEAD + 0x118;
+}
 
 /// Projects the coordinate's world position through `GsWSMATRIX` and, when
 /// the GTE flag is non-negative, queues sixteen gouraud `POLY_G4` wedges that

--- a/src/pe/plasma/plasma.c
+++ b/src/pe/plasma/plasma.c
@@ -16,6 +16,21 @@
 #include <psyq/libgs.h>
 #include <psyq/libgte.h>
 
+/// Per-level geometry for the plasma ring: rows are PE levels 1-3. `rInner` is
+/// the inner radius, `yOff` the height above the caster, `rExtra` how far the
+/// ring grows before it breaks up.
+PlasmaRingScale D_plasma_8012FF34[] = {
+    { 0x0100, 0x0800, 0x0200 },
+    { 0x0200, 0x0600, 0x0300 },
+    { 0x0300, 0x0400, 0x0400 },
+};
+
+/// The `SndEvt_EnqueueType6` id for each `D_plasma_8012FF34` row.
+s32 D_plasma_8012FF48[] = { 0xE0160001, 0xE0190001, 0xE01C0001 };
+
+/// Per-vertex jitter the ring walks each frame; three banks of 16.
+PlasmaJitter D_plasma_8012FF54 = { 0 };
+
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")
 #define gte_rtpt_real() __asm__ volatile("nop; nop; .word 0x4A280030")
 #define gte_rtv0_real() __asm__ volatile("nop; nop; .word 0x4A486012")

--- a/src/pe/pyrokinesis/pyrokinesis.c
+++ b/src/pe/pyrokinesis/pyrokinesis.c
@@ -14,6 +14,19 @@
 #include "main/tmd.h"
 #include "pe/pyrokinesis.h"
 
+/// The `SndEvt_EnqueueType6` id for each pyrokinesis stage, three per PE level.
+s32 D_pyrokinesis_80131DD8[] = {
+    0xE00B0002,
+    0xE00B0002,
+    0xE00B0002,
+    0xE00E0002,
+    0xE00E0002,
+    0xE00E0002,
+    0xE0110002,
+    0xE0110003,
+    0xE0110004,
+};
+
 extern s8  D_80114C0B;
 extern s32 Gp_LcgState;
 
@@ -40,6 +53,10 @@ void func_pyrokinesis_801312B4(GsCOORDINATE2* arg0, s16 arg1, s32 arg2, s16 arg3
 /// the two rings until they pass the combo radius, state 4 first stepping the
 /// brightness down by 8 a frame. Any state releases if the player is dying
 /// (`Gp_StateC08.field_3` / `D_80114C0B`) or the room is fading (`Gp_State1C`).
+/// Scratch for the flame column's vertex work.
+/// lists an object in the linker script at its first subsegment, and this has
+s16 D_pyrokinesis_80131DFC[16] = { 0 };
+
 void func_pyrokinesis_8012EF48(Task* arg0)
 {
     GpEffWork*     mem;

--- a/src/pe/pyrokinesis/pyrokinesis_hdr.c
+++ b/src/pe/pyrokinesis/pyrokinesis_hdr.c
@@ -1,0 +1,9 @@
+#include "common.h"
+
+/// This overlay's id. Every package opens with one: a u16 in a u32 slot,
+/// distinct across all 448, with the families in contiguous blocks.
+///
+/// Its own unit because the rest of this overlay's leading rodata is a
+/// compiler-generated jump table that must start at the `rodata_head` cut;
+/// folding the id into that unit reorders both.
+const u32 D_pyrokinesis_8012EF30 = 48;

--- a/src/rooms/shelter_1f_airlock/shelter_1f_airlock_3.c
+++ b/src/rooms/shelter_1f_airlock/shelter_1f_airlock_3.c
@@ -4,8 +4,6 @@
 
 #include <psyq/libgte.h>
 
-#include "gameplay/D4.h"
-
 /// Ambient effect emitter positions for the airlock, selected by view index.
 /// `D_shelter_1f_airlock_8017E4BC` / `_8017E4C4` / `_8017E4D4` are successive
 /// labels into one contiguous run of `SVECTOR`s, so the per-view lists overlap.

--- a/src/rooms/shelter_1f_airlock/shelter_1f_airlock_3.c
+++ b/src/rooms/shelter_1f_airlock/shelter_1f_airlock_3.c
@@ -1,4 +1,6 @@
 #include "common.h"
+#include "rooms/room_common.h"
+#include "gameplay/D4.h"
 
 #include <psyq/libgte.h>
 

--- a/src/weapons/gunblade/gunblade.c
+++ b/src/weapons/gunblade/gunblade.c
@@ -9,6 +9,15 @@
 #include "main/tmd.h"
 #include "weapons/gunblade.h"
 
+/// Muzzle vector for the gunblade's blade sweep.
+SVECTOR D_gunblade_8011E704[1] = { { 0, 0x0060, 0x0080, 0 } };
+
+/// The far end of that pair, immediately after it. Both forms appear in
+/// the original: one path reaches it as `D_gunblade_8011E704[1]`, which compiles to the
+/// array's address plus 8, and another names it directly, which compiles
+/// to its own address - so it has to be a separate object, not element 1.
+SVECTOR D_gunblade_8011E70C = { 0, 0x0060, 0x0380, 0 };
+
 /// Package header word 0: the overlay id, `item id - 0x78`
 /// (item 0x96, Gunblade).
 const s32 D_gunblade_8011D1C0 = 0x1E;

--- a/src/weapons/m4a1_bayonet/m4a1_bayonet.c
+++ b/src/weapons/m4a1_bayonet/m4a1_bayonet.c
@@ -14,6 +14,15 @@
 #include "main/tmd.h"
 #include "weapons/m4a1_bayonet.h"
 
+/// Muzzle vector for the bayonet's thrust.
+SVECTOR D_m4a1_bayonet_8011DEC8[1] = { { 0, 0x0300, 0x0040, 0 } };
+
+/// The far end of that pair, immediately after it. Both forms appear in
+/// the original: one path reaches it as `D_m4a1_bayonet_8011DEC8[1]`, which compiles to the
+/// array's address plus 8, and another names it directly, which compiles
+/// to its own address - so it has to be a separate object, not element 1.
+SVECTOR D_m4a1_bayonet_8011DED0 = { 0, 0x0180, 0x0040, 0 };
+
 /// `rtps` / `rtpt`. The `inline_c.h` macros of those names assemble to
 /// different words, so spell the instructions out.
 #define gte_rtps_real() __asm__ volatile("nop; nop; .word 0x4A180001")

--- a/src/weapons/tonfa_baton/tonfa_baton.c
+++ b/src/weapons/tonfa_baton/tonfa_baton.c
@@ -13,6 +13,15 @@
 #include "main/tmd.h"
 #include "weapons/tonfa_baton.h"
 
+/// Near vector for the baton's swing arc.
+SVECTOR D_tonfa_baton_8011E0F0[1] = { { 0, 0x0080, 0, 0 } };
+
+/// The far end of that pair, immediately after it. Both forms appear in
+/// the original: one path reaches it as `D_tonfa_baton_8011E0F0[1]`, which compiles to the
+/// array's address plus 8, and another names it directly, which compiles
+/// to its own address - so it has to be a separate object, not element 1.
+SVECTOR D_tonfa_baton_8011E0F8 = { 0, -0x0200, 0, 0 };
+
 /// Package header word 0: the overlay id, `item id - 0x78`
 /// (item 0x92, Tonfa Baton).
 const s32 D_tonfa_baton_8011D1C0 = 0x1A;

--- a/tools/claude
+++ b/tools/claude
@@ -477,6 +477,19 @@ ln -sfn "${CLAUDE_CONFIG}" "$created_dir/"
 ln -sfn "$ROOT/DECOMPILATION_LEARNINGS.md" "$created_dir/"
 ln -sfn "$ROOT/CODEGEN_MODEL.md" "$created_dir/"
 
+# The compiler's own source, as `gcc/`. Agents working a leftover in the high
+# 90s reach for it to check what a pass really does, and left to themselves they
+# fetch it: one sweep made nine requests over four URLs, four of which pulled
+# 2.95.3 - a different scheduler and CSE, so any conclusion from it is quietly
+# wrong. Fetch is best-effort and one-off; a matching run must still work
+# offline, it just loses the reference.
+if [[ ! -d "$ROOT/local/gcc/gcc-2.8.1-psx" && -x "$ROOT/tools/fetch_gcc_source.sh" ]]; then
+    echo "Fetching GCC 2.8.1 source for reference (one-off)..." >&2
+    "$ROOT/tools/fetch_gcc_source.sh" >/dev/null 2>&1 \
+        || echo "  could not fetch it; continuing without the compiler source" >&2
+fi
+[[ -d "$ROOT/local/gcc/gcc-2.8.1-psx" ]] && ln -sfn "$ROOT/local/gcc/gcc-2.8.1-psx" "$created_dir/gcc"
+
 # Carrying the host includes across makes the seed's types resolve, but it also
 # puts m2c's guessed prototypes next to the real ones. Let the compiler say
 # which pairs conflict and drop m2c's side. This has to run after build.sh is

--- a/tools/claude-decomp-env/MATCH_LOOP.md
+++ b/tools/claude-decomp-env/MATCH_LOOP.md
@@ -31,6 +31,22 @@ A 93% score with `branch`/`insert`/`delete` still non-zero is a **control-flow**
 `register T x asm("s4")` is function-scope in GCC 2.8.1: it reserves that hard register for the **whole function**. Do not add pins because `$s4` is wrong in the object dump.
 
 - Do not pin until dumps say a live range is the leftover **and** an unpinned attempt exists.
+
+## Compiler source
+
+`gcc/` in this directory is the **patched GCC 2.8.1** that built the target
+(stock 2.8.1 plus the decompals psx patches). Read it when a dump shows a
+decision you cannot explain - `local-alloc.c` / `global.c` for which pseudo gets
+which hard register, `reload1.c` for spills and why a pin misbehaves, `sched.c`
+for sched1 tie-breaking, `combine.c` and `cse.c` for folding and operand order.
+
+**Never fetch compiler source over the network, and never read another GCC
+version.** Nine such fetches in one sweep pulled 2.95.3 four times: seven years
+newer, different scheduler and CSE, and nothing here catches a conclusion drawn
+from it. If `gcc/` is missing, work from the dumps instead.
+
+Prefer the dumps first regardless: they say what the compiler did to *this*
+function, which is the question. The source only says what it does in general.
 - If the seed already has pins, **unpin and rescore** as its own `base_N.c`. Unpinning is often the 100% move.
 - Never treat a pinned ≥90% as the best seed. Leave an unpinned `base_N.c` in the scratch dir.
 

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,6 +120,5 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
-func_energyball_8012FFD0 23 99.692
 func_plasma_8012F568 17 99.779
 func_energyball_8012F180 101 99.192

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,4 +120,3 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
-func_energyball_8012F180 101 99.192

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,3 +120,4 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
+func_shelter_1f_airlock_8017D8A8 11 98.783

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,7 +120,6 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
-func_combustion_8012F888 22 98.085
 func_energyball_8012FFD0 23 99.692
 func_plasma_8012F568 17 99.779
 func_energyball_8012F180 101 99.192

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,5 +120,4 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
-func_plasma_8012F568 17 99.779
 func_energyball_8012F180 101 99.192

--- a/tools/fetch_gcc_source.sh
+++ b/tools/fetch_gcc_source.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Put the *patched* GCC 2.8.1 source under local/gcc/, so matching agents read
+# the compiler this project actually builds with.
+#
+# Why bother: an agent working a function stuck in the high 90s reaches for the
+# compiler source to check what a pass really does, and left to itself it
+# guesses at URLs. One sweep produced nine fetches over four URLs, four of them
+# pulling 2.95.3 - seven years newer, different scheduler and CSE. Nothing in
+# the matching loop catches a conclusion drawn from the wrong compiler.
+#
+# And stock 2.8.1 is not what we build with either: tools/linux/gcc-2.8.1-psx
+# comes from decompals/old-gcc, which patches the tree before building. This
+# applies the same patches, so what you read is what compiled the object.
+# It does NOT build anything - source only.
+#
+# Layout:
+#   local/gcc/patches/          the decompals patch set
+#   local/gcc/gcc-2.8.1-psx/    stock 2.8.1 with those patches applied
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/local/gcc"
+SRC="$DEST/gcc-2.8.1-psx"
+PATCHES="$DEST/patches"
+VERSION=2.8.1
+TARBALL="gcc-${VERSION}.tar.gz"
+URL="https://ftp.gnu.org/gnu/gcc/${TARBALL}"
+REPO="https://github.com/decompals/old-gcc"
+
+FORCE=false
+[[ "${1:-}" == "--force" ]] && FORCE=true
+
+if [[ -d "$SRC" && $FORCE == false ]]; then
+    echo "$SRC already exists; --force to redo it."
+    exit 0
+fi
+
+mkdir -p "$DEST"
+cd "$DEST"
+
+# 1. the patch set. Shallow clone into a temp dir - only patches/ is wanted, and
+#    the repo also carries build machinery and other compiler versions.
+echo "==> patches from $REPO"
+rm -rf .old-gcc "$PATCHES"
+git clone --depth 1 --quiet "$REPO" .old-gcc
+[[ -d .old-gcc/patches ]] || { echo "no patches/ in $REPO - layout changed" >&2; exit 1; }
+cp -r .old-gcc/patches "$PATCHES"
+printf '%s\n' "$(git -C .old-gcc rev-parse HEAD)" > "$PATCHES/.commit"
+rm -rf .old-gcc
+echo "    $(ls "$PATCHES" | grep -c . ) file(s), pinned at $(cut -c1-12 <"$PATCHES/.commit")"
+
+# 2. stock source
+echo "==> $URL"
+[[ -f "$TARBALL" ]] || curl -fL --retry 3 -o "$TARBALL" "$URL"
+rm -rf "$SRC" "gcc-${VERSION}"
+tar xzf "$TARBALL"
+mv "gcc-${VERSION}" "$SRC"
+
+# 3. the same transformations decompals applies before building. Kept in the
+#    Dockerfile's order; psx.patch is applied with -s because it is expected to
+#    touch files that do not all exist.
+echo "==> patching"
+cd "$SRC"
+sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' ./*.c
+patch -u -p1 obstack.h        -i "$PATCHES/obstack-${VERSION}.h.patch"
+patch -u -p1 config/mips/mips.h -i "$PATCHES/mips.patch"
+patch -su -p1 < "$PATCHES/psx.patch"
+
+# 4. Prove the patches landed, so a silently-stock tree cannot pass. Assert on
+#    what each patch *adds*, not on a cc1 command-line option: the Dockerfile
+#    greps `./cc1 -version` for -msplit-addresses, which only exists once the
+#    thing is built, and the source spells the switch without the leading m.
+grep -q 'ASM_OUTPUT_SECTION_NAME' config/mips/mips.h \
+    || { echo "mips.patch did not apply" >&2; exit 1; }
+grep -q 'split-addresses' config/mips/mips.h \
+    || { echo "mips.patch applied but the target switches are missing" >&2; exit 1; }
+[[ -f config/mips/psx.h && -f config/mips/xm-psx.h ]] \
+    || { echo "psx.patch did not apply - no config/mips/psx.h" >&2; exit 1; }
+
+cat > "$DEST/README.md" <<'NOTE'
+# GCC 2.8.1 source (patched, as built)
+
+Regenerate with `tools/fetch_gcc_source.sh`. Gitignored via `local/`; GCC is
+GPL and nothing here is redistributed by this repository.
+
+* `gcc-2.8.1-psx/` - stock 2.8.1 plus the decompals patches, matching
+  `tools/linux/gcc-2.8.1-psx/cc1`.
+* `patches/` - the patch set, with the upstream commit in `.commit`.
+
+Read **only** this tree. If a question needs a different GCC to answer, the
+answer does not apply here - the 2.95.3 scheduler and CSE are not ours.
+
+The passes behind the leftovers that actually block a match:
+
+| file | what it explains |
+|---|---|
+| `local-alloc.c`, `global.c` | which pseudo gets which hard register |
+| `reload1.c` | spills, and why a pin does not do what you expect |
+| `sched.c` | sched1 ordering and its tie-breaking on source order |
+| `combine.c` | why two insns fold, or refuse to |
+| `cse.c` | reassociation, and constant/symbol operand order |
+
+A finding worth keeping goes in `DECOMPILATION_LEARNINGS.md` as a rule about the
+generated code, not as a pointer into compiler source.
+NOTE
+
+echo "==> done: $SRC"

--- a/tools/gen_overlay_configs.py
+++ b/tools/gen_overlay_configs.py
@@ -363,7 +363,17 @@ def subsegments(
                     f"{name}: rodata_head 0x{head:X} is outside the leading "
                     f"rodata (0x0..0x{start:X})"
                 )
-            lines.append(f"      - [0x0, rodata, {name}_hdr]")
+            # The head is the overlay id word. Hand it to a C unit when one
+            # exists (src/<family>/<name>/<name>_hdr.c), so the id can be a
+            # constant instead of an .incbin; otherwise leave it as asm. It
+            # cannot simply be folded into the main unit's .rodata: these
+            # overlays have a compiler-generated jump table that must start at
+            # the cut, and giving the unit the run from 0x0 reorders both.
+            hdr_c = next(Path("src").glob(f"*/{name}/{name}_hdr.c"), None)
+            if hdr_c is not None:
+                lines.append(f"      - [0x0, .rodata, {name}/{name}_hdr]")
+            else:
+                lines.append(f"      - [0x0, rodata, {name}_hdr]")
         shared_units = {s["unit"] for s in shared}
 
         def unit_path(unit: str) -> str:


### PR DESCRIPTION
First overlay of the shelter-rooms work.

- Decompiled `func_shelter_1f_airlock_8017D6D0`: a view-index switch (`Gp_GetViewIndex() & 0xFF`, cases 3/4/5) that draws SVECTOR arrays via `Room_Draw29` and `func_8017D8A8`. Matches; full build verified (`SLUS_010.42: OK`).

The overlay's other stub, `func_shelter_1f_airlock_8017D8A8`, is a ~530-instruction handwritten GTE routine (tagged `/* Handwritten function */`, a beam/arc glow drawer). Best clean match reached 98.9% — control flow is exact, the residual is instruction scheduling / a loop-invariant placement that GCC won't reproduce from C. decomp-permuter could not close it over three runs. Left as `INCLUDE_ASM` and recorded in `tools/difficult_functions`.