### PR TITLE
Match shelter_r49 overlay

### DIFF
--- a/src/rooms/shelter_r49/shelter_r49.c
+++ b/src/rooms/shelter_r49/shelter_r49.c
@@ -1,5 +1,17 @@
 #include "common.h"
 
+#include "gameplay/3CD8.h"
+#include "gameplay/D4.h"
+
+#include "main/session.h"
+#include "main/task.h"
+
+extern GpMsgEntry D_shelter_r49_8017D9D8[];
+
+extern s8  D_8007218B;
+extern s32 D_80133560;
+extern s32 D_80133860;
+
 s32 func_shelter_r49_8017D638(void)
 {
     return 0;
@@ -10,7 +22,15 @@ s32 func_shelter_r49_8017D640(void)
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_r49/shelter_r49", func_shelter_r49_8017D648);
+void func_shelter_r49_8017D648(Task* arg0)
+{
+    arg0->field_24 = D_shelter_r49_8017D9D8;
+    Game_SetPtrSlot(arg0, 7);
+    if (D_8007218B != 9) {
+        func_800E8634((s32)&D_80133560, 0, (s32)&D_80133860);
+    }
+    arg0->state = (s32)(arg0->state + 1);
+}
 
 INCLUDE_RODATA("rooms/nonmatchings/shelter_r49/shelter_r49", D_shelter_r49_8017D5C0);
 

--- a/src/rooms/shelter_r49/shelter_r49_2.c
+++ b/src/rooms/shelter_r49/shelter_r49_2.c
@@ -1,12 +1,20 @@
 #include "common.h"
 
+#include "gameplay/gameplay.h"
+
 #include "main/display.h"
 #include "main/fs.h"
+#include "main/mc.h"
 #include "main/mem.h"
 #include "main/pad.h"
 #include "main/session.h"
 #include "main/stream.h"
 #include "main/task.h"
+
+extern TaskDesc D_shelter_r49_8017DA00;
+
+extern s8  D_8007106B;
+extern s16 D_80071076;
 
 void func_shelter_r49_8017D71C(Task* arg0)
 {
@@ -92,7 +100,31 @@ L_case6:
     Display_ResetHeapWrapper();
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_r49/shelter_r49_2", func_shelter_r49_8017D8D8);
+void func_shelter_r49_8017D8D8(Task* arg0)
+{
+    switch (arg0->state) {
+        case 0:
+            Display_SpawnWithOt(&D_shelter_r49_8017DA00, 1, 0, 0);
+            D_8007106B = 1;
+            Gp_SpawnViewTasks();
+            arg0->state = arg0->state + 1;
+            break;
+        case 1:
+        case 2:
+            arg0->state = arg0->state + 1;
+            break;
+        case 3:
+            SetDispMask(1);
+            Mc_SaveData.field_7 = 5;
+            Mc_SaveData.field_6 = 7;
+            Mc_SaveData.field_8 = 1;
+            Mc_SaveData.field_5 = 1;
+            D_80071076          = 1;
+            Task_Spawn(0, 0x11, 0, 0);
+            Task_Kill(arg0);
+            break;
+    }
+}
 
 void func_shelter_r49_8017D9D0(void)
 {


### PR DESCRIPTION
Decompiles both remaining INCLUDE_ASM stubs in the shelter_r49 room overlay, bringing it to zero INCLUDE_ASM.

- func_shelter_r49_8017D648 — task init: sets the message-table slot, spawns via func_800E8634 unless D_8007218B == 9, advances state.
- func_shelter_r49_8017D8D8 — task state machine (states 0/1-2/3): view spawn, save-data fields, Task_Spawn + Task_Kill.

Full build verified: SLUS_010.42: OK.