### PR TITLE
matched shelter_1f_tent (2 of 3 stubs)

### DIFF
--- a/src/rooms/shelter_1f_tent/shelter_1f_tent_3.c
+++ b/src/rooms/shelter_1f_tent/shelter_1f_tent_3.c
@@ -1,5 +1,19 @@
 #include "common.h"
 
+#include "rooms/room_common.h"
+
+extern void func_801322B8(void);
+extern void func_80132390(void);
+
 INCLUDE_ASM("rooms/nonmatchings/shelter_1f_tent/shelter_1f_tent_3", func_shelter_1f_tent_8017FCA0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_tent/shelter_1f_tent_3", func_shelter_1f_tent_8017FD54);
+s32 func_shelter_1f_tent_8017FD54(s32 arg0, s32 arg1, RoomEventMsg* arg2)
+{
+    if (arg2->field_2 == 1) {
+        func_801322B8();
+    }
+    if (arg2->field_2 == 2) {
+        func_80132390();
+    }
+    return 0;
+}

--- a/src/rooms/shelter_1f_tent/shelter_1f_tent_4.c
+++ b/src/rooms/shelter_1f_tent/shelter_1f_tent_4.c
@@ -1,3 +1,61 @@
 #include "common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_tent/shelter_1f_tent_4", func_shelter_1f_tent_8017FE10);
+#include <psyq/libgte.h>
+
+#include "gameplay/D4.h"
+#include "rooms/room_common.h"
+
+extern SVECTOR D_shelter_1f_tent_80181D04[];
+extern SVECTOR D_shelter_1f_tent_80181D0C[];
+extern SVECTOR D_shelter_1f_tent_80181D1C[];
+extern SVECTOR D_shelter_1f_tent_80181D2C[];
+extern SVECTOR D_shelter_1f_tent_80181D3C[];
+
+void func_shelter_1f_tent_8017FE10(void)
+{
+    u8 view;
+
+    view = Gp_GetViewIndex();
+    switch (view) {
+        case 2: {
+            SVECTOR* p = D_shelter_1f_tent_80181D2C;
+            Room_Draw01(&p[0], 0x200, 0x111);
+            Room_Draw13(&p[-5], 0x280, 0x40);
+            Room_Draw13(&p[-4], 0x280, 0x444);
+            Room_Draw13(&p[-3], 0x180, 0x22);
+            Room_Draw13(&p[-2], 0x280, 0x444);
+            Room_Draw13(&p[-1], 0x180, 0x22);
+            Room_Draw32(&D_shelter_1f_tent_80181D3C[0], 0x60, 0x80);
+            break;
+        }
+        case 3: {
+            SVECTOR* p = D_shelter_1f_tent_80181D04;
+            Room_Draw13(&p[0], 0x280, 0x40);
+            Room_Draw13(&p[1], 0x280, 0x444);
+            Room_Draw13(&p[2], 0x180, 0x22);
+            Room_Draw32(&p[7], 0x60, 0x80);
+            break;
+        }
+        case 5: {
+            SVECTOR* p = D_shelter_1f_tent_80181D0C;
+            Room_Draw13(&p[0], 0x280, 0x444);
+            Room_Draw05(&p[6], 0x60, 0x80);
+            break;
+        }
+        case 4:
+        case 6: {
+            SVECTOR* p = D_shelter_1f_tent_80181D1C;
+            Room_Draw13(&p[0], 0x280, 0x444);
+            Room_Draw13(&p[1], 0x180, 0x22);
+            break;
+        }
+        case 7: {
+            SVECTOR* p = D_shelter_1f_tent_80181D04;
+            Room_Draw13(&p[0], 0x280, 0x40);
+            Room_Draw13(&p[1], 0x280, 0x444);
+            Room_Draw13(&p[2], 0x180, 0x22);
+            Room_Draw32(&D_shelter_1f_tent_80181D3C[0], 0x60, 0x80);
+            break;
+        }
+    }
+}

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -121,3 +121,4 @@ func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
 func_shelter_1f_airlock_8017D8A8 11 98.783
+func_shelter_1f_tent_8017FCA0 1 55.556


### PR DESCRIPTION
Decompiles 2 of the 3 remaining INCLUDE_ASM stubs in the shelter_1f_tent overlay.

- func_shelter_1f_tent_8017FD54 - message dispatch on RoomEventMsg->field_2 (calls func_801322B8 / func_80132390)
- func_shelter_1f_tent_8017FE10 - per-view scenery draw dispatch: switch on Gp_GetViewIndex(), each case draws a set of SVECTOR quads via Room_Draw01/13/05/32

func_shelter_1f_tent_8017FCA0 is left as INCLUDE_ASM: it floors around 55% on a register/scheduling cascade over a block of 0x551C000X constants (the retail build hoists the first lui into the bnez delay slot; compute order does not equal store order). Recorded in tools/difficult_functions.

Full unscoped build verifies: SLUS_010.42 matches, 424 matched functions still C.