### PR TITLE
matched shelter_b3_incinerator_control_room (3 of 4 stubs)

### DIFF
--- a/src/rooms/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2.c
+++ b/src/rooms/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2.c
@@ -1,5 +1,20 @@
 #include "common.h"
 
+#include "gameplay/3CD8.h"
+#include "gameplay/D4.h"
+#include "main/gameflag.h"
+#include "main/session.h"
+#include "main/sound.h"
+#include "main/task.h"
+#include "rooms/room_common.h"
+
+extern s32 func_80179A04(RoomEventMsg* in, RoomEventMsg* out);
+
+extern GpMsgEntry     D_shelter_b3_incinerator_control_room_80181838[];
+extern GpAreaApplyRec D_shelter_b3_incinerator_control_room_80182A40[];
+extern s32            D_801360E4;
+extern s32            D_80136804;
+
 INCLUDE_RODATA("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", RoomsShared8017ef20Title);
 INCLUDE_RODATA("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", RoomsShared8017de9cHundred);
 INCLUDE_RODATA("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", RoomsShared8017e8b4WeaponTitle);
@@ -11,7 +26,23 @@ s32 func_shelter_b3_incinerator_control_room_8017FA84(void)
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", func_shelter_b3_incinerator_control_room_8017FA8C);
+s32 func_shelter_b3_incinerator_control_room_8017FA8C(s32 arg0, s32 arg1, RoomEventMsg* in, RoomEventMsg* out)
+{
+    *out = *in;
+    func_80179A04(in, out);
+    if (in->msgId != 0x2A) {
+        return 1;
+    }
+    if (GameFlag_GetNibble(0xA7) != 0) {
+        return 1;
+    }
+    if (in->field_5 != 0) {
+        return 0;
+    }
+    Gp_SetNibbleIf(in->field_6, 2);
+    Gp_RunCapCmd1(3);
+    return 0;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", func_shelter_b3_incinerator_control_room_8017FB20);
 
@@ -20,6 +51,23 @@ s32 func_shelter_b3_incinerator_control_room_8017FBE0(void)
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", func_shelter_b3_incinerator_control_room_8017FBE8);
+s32 func_shelter_b3_incinerator_control_room_8017FBE8(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 0x63) {
+        SndEvt_EnqueueType6(0x54290009, 0, 0);
+    }
+    return 0;
+}
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_incinerator_control_room/shelter_b3_incinerator_control_room_2", func_shelter_b3_incinerator_control_room_8017FC1C);
+void func_shelter_b3_incinerator_control_room_8017FC1C(Task* task)
+{
+    task->field_24 = D_shelter_b3_incinerator_control_room_80181838;
+    Game_SetPtrSlot(task, 7);
+    task->state++;
+    if (Game_Session->field_8 == 4) {
+        func_800E3FAC(0xA2, 0x23);
+        Gp_ApplyAreaRecs(D_shelter_b3_incinerator_control_room_80182A40);
+        Gp_FillAllyHp();
+        func_800E8634((s32)&D_801360E4, 0, (s32)&D_80136804);
+    }
+}

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -121,3 +121,4 @@ func_acropolis_plaza_801811D0 121 98.57
 func_options_801D42A8 30 99.636
 func_options_801D4D0C 17 78.919
 func_shelter_1f_airlock_8017D8A8 11 98.783
+func_shelter_b3_incinerator_control_room_8017FB20 3 87.5


### PR DESCRIPTION
Decompiles 3 of the 4 remaining INCLUDE_ASM stubs in the shelter_b3_incinerator_control_room overlay.

- func_shelter_b3_incinerator_control_room_8017FA8C - room event gate: copies the incoming RoomEventMsg, forwards to func_80179A04, then gates on msgId 0x2A / flag 0xA7 / field_5 (returns 0 or 1)
- func_shelter_b3_incinerator_control_room_8017FBE8 - message-gated SndEvt_EnqueueType6
- func_shelter_b3_incinerator_control_room_8017FC1C - ptr-slot task setup; when Game_Session->field_8 == 4 applies area records, fills ally HP and spawns

func_shelter_b3_incinerator_control_room_8017FB20 is left as INCLUDE_ASM: it floors around 88% (6 instructions) on a spawn-descriptor constant-block scheduling artifact - the retail build computes the packed 0x54290001..4 constants in field order but stores them in a different order, which C source order cannot express (compute and store order are coupled). Recorded in tools/difficult_functions.

Full unscoped build verifies: SLUS_010.42 matches, 424 matched functions still C.