### PR TITLE
matched shelter_1f_guardroom (2 of 5 stubs)

### DIFF
--- a/src/rooms/shelter_1f_guardroom/shelter_1f_guardroom_2.c
+++ b/src/rooms/shelter_1f_guardroom/shelter_1f_guardroom_2.c
@@ -1,23 +1,43 @@
 #include "common.h"
 
+#include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
 
 #include "main/gameflag.h"
 #include "main/session.h"
+#include "main/sound.h"
 #include "main/task.h"
 
 extern GpMsgEntry D_shelter_1f_guardroom_8017DA30[];
+extern TaskDesc   D_shelter_1f_guardroom_8017DA60;
 
 void func_shelter_1f_guardroom_8017D9CC(s32);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_guardroom/shelter_1f_guardroom_2", func_shelter_1f_guardroom_8017D788);
+s32 func_shelter_1f_guardroom_8017D788(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 2) {
+        if (GameFlag_GetNibble(0xB2) == 0) {
+            Gp_MsgPlayerWeapon(0);
+            Task_SpawnFromTable(&D_shelter_1f_guardroom_8017DA60, 0, 0, 0);
+        } else {
+            Gp_RunCapCmd1(3);
+        }
+    }
+    return 0;
+}
 
 s32 func_shelter_1f_guardroom_8017D7E8(void)
 {
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_guardroom/shelter_1f_guardroom_2", func_shelter_1f_guardroom_8017D7F0);
+s32 func_shelter_1f_guardroom_8017D7F0(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 3) {
+        SndEvt_EnqueueType6(0x55060003, 0, 0);
+    }
+    return 0;
+}
 
 void func_shelter_1f_guardroom_8017D824(Task* arg0)
 {


### PR DESCRIPTION
Decompiles 2 of the 5 remaining INCLUDE_ASM stubs in the shelter_1f_guardroom overlay.

- func_shelter_1f_guardroom_8017D788 - event handler: on event id 2, gates on GameFlag 0xB2, then either Gp_MsgPlayerWeapon + Task_SpawnFromTable or Gp_RunCapCmd1
- func_shelter_1f_guardroom_8017D7F0 - event handler: on event id 3, SndEvt_EnqueueType6

Left as INCLUDE_ASM for a future focused pass:
- func_shelter_1f_guardroom_8017D5E8 - its compiler jump table sits in the leading rodata at 0x14 (the same .align 3 wall that shelter_b2_elevator solved with a units+rodata manifest cut)
- func_shelter_1f_guardroom_8017D8D8 - Cd/Stream state machine; the retail build keeps &CdCmd_Queue and the constant 1 in saved registers across the whole switch, which C source order does not reproduce
- func_shelter_1f_guardroom_8017D9CC - Gp_SprtTables pointer chain whose element type is still ambiguous

Full unscoped build verifies: SLUS_010.42 matches, 424 matched functions still C.