### PR TITLE
matched 2 more shelter_1f_guardroom funcs (8017D788, 8017D7F0)

### DIFF
--- a/src/rooms/shelter_1f_guardroom/shelter_1f_guardroom_2.c
+++ b/src/rooms/shelter_1f_guardroom/shelter_1f_guardroom_2.c
@@ -1,23 +1,43 @@
 #include "common.h"
 
+#include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
 
 #include "main/gameflag.h"
 #include "main/session.h"
+#include "main/sound.h"
 #include "main/task.h"
 
 extern GpMsgEntry D_shelter_1f_guardroom_8017DA30[];
+extern TaskDesc   D_shelter_1f_guardroom_8017DA60;
 
 void func_shelter_1f_guardroom_8017D9CC(s32);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_guardroom/shelter_1f_guardroom_2", func_shelter_1f_guardroom_8017D788);
+s32 func_shelter_1f_guardroom_8017D788(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 2) {
+        if (GameFlag_GetNibble(0xB2) == 0) {
+            Gp_MsgPlayerWeapon(0);
+            Task_SpawnFromTable(&D_shelter_1f_guardroom_8017DA60, 0, 0, 0);
+        } else {
+            Gp_RunCapCmd1(3);
+        }
+    }
+    return 0;
+}
 
 s32 func_shelter_1f_guardroom_8017D7E8(void)
 {
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_guardroom/shelter_1f_guardroom_2", func_shelter_1f_guardroom_8017D7F0);
+s32 func_shelter_1f_guardroom_8017D7F0(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 3) {
+        SndEvt_EnqueueType6(0x55060003, 0, 0);
+    }
+    return 0;
+}
 
 void func_shelter_1f_guardroom_8017D824(Task* arg0)
 {


### PR DESCRIPTION
Follow-up to #10. Matches two more `shelter_1f_guardroom` functions:

- `func_shelter_1f_guardroom_8017D788`
- `func_shelter_1f_guardroom_8017D7F0`

Verified with unscoped `./tools/build-and-verify.sh` — `SLUS_010.42: OK`, all 424 matched functions still C.

Remaining guardroom stubs are known walls (`8017D5E8` jtbl, `8017D8D8` Cd/Stream reg-hoist, `8017D9CC` Gp_SprtTables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)