### PR TITLE
matched shelter_1f_bulwark (2 of 5 stubs)

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -52904,3 +52904,35 @@ directions: use an initializer to nail the prologue saves to the top, use
 assignments to let them drift into the body. Read the block's `.sched2` dump
 for the clobber insn (`clobber (mem/s:BLK ...)`) before guessing which side a
 mismatch is on.
+
+## A redundant `Type* local = arg0;` copy defers the callee-saved-reg spill
+
+Room state machine `func_shelter_1f_bulwark_8017DE04`: `arg0` (a `Task*`) is
+live across a call in `case 0` and reused in `case 3`, so it must live in a
+callee-saved reg. Target copies it in the prologue —
+
+```
+addiu $sp, $sp, -0x20
+sw    $s1, 0x14($sp)
+addu  $s1, $a0, $zero      # s1 = arg0, before the other saves
+sw    $ra, 0x18($sp)
+sw    $s0, 0x10($sp)
+lw    $v1, 0x30($s1)       # state read via s1
+```
+
+Writing the body over an explicit alias —
+
+```c
+Task* task = arg0;
+switch (task->state) { ... Task_Kill(task); }
+```
+
+made GCC read state via `a0` and slip the `move $s1, $a0` into the delay slot
+of the first `beqz`, and reordered the register saves to `ra, s1, s0`. Dropping
+the local and using `arg0` throughout (`switch (arg0->state)`, `Task_Kill(arg0)`)
+forced the early prologue copy and the `s1, ra, s0` save order — instant match.
+
+Rule: when the prologue's saved-reg copy/order is the only diff and a parameter
+is aliased to a local, delete the alias and use the parameter directly. The
+extra copy gives the scheduler a second placement it can defer; the direct use
+does not.

--- a/src/rooms/shelter_1f_bulwark/shelter_1f_bulwark_3.c
+++ b/src/rooms/shelter_1f_bulwark/shelter_1f_bulwark_3.c
@@ -1,12 +1,19 @@
 #include "common.h"
 
+#include "gameplay/gameplay.h"
 #include "main/display.h"
 #include "main/fs.h"
+#include "main/mc.h"
 #include "main/mem.h"
 #include "main/pad.h"
 #include "main/session.h"
 #include "main/stream.h"
 #include "main/task.h"
+
+extern s8       D_8007106B;
+extern s16      D_80071076;
+extern s8       D_801153F4;
+extern TaskDesc D_shelter_1f_bulwark_80180360;
 
 void func_shelter_1f_bulwark_8017DC78(Task* arg0)
 {
@@ -81,4 +88,28 @@ L_case5:
     Display_ResetHeapWrapper();
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_bulwark/shelter_1f_bulwark_3", func_shelter_1f_bulwark_8017DE04);
+void func_shelter_1f_bulwark_8017DE04(Task* arg0)
+{
+    switch (arg0->state) {
+        case 0:
+            Display_SpawnWithOt(&D_shelter_1f_bulwark_80180360, 1, 0, 0);
+            D_8007106B = 1;
+            Gp_SpawnViewTasks();
+            D_801153F4 = 1;
+            /* fallthrough */
+        case 1:
+        case 2:
+            arg0->state = arg0->state + 1;
+            break;
+        case 3:
+            Mc_SaveData.field_7 = 5;
+            Mc_SaveData.field_6 = 0x1A;
+            Mc_SaveData.field_8 = 1;
+            Mc_SaveData.field_5 = 1;
+            D_80071076          = 1;
+            Fs_BeginBootLoad(&Mc_SaveData.field_4, 0);
+            Task_Spawn(0, 0x11, 0x10, 0);
+            Task_Kill(arg0);
+            break;
+    }
+}

--- a/src/rooms/shelter_1f_bulwark/shelter_1f_bulwark_4.c
+++ b/src/rooms/shelter_1f_bulwark/shelter_1f_bulwark_4.c
@@ -1,3 +1,40 @@
 #include "common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_1f_bulwark/shelter_1f_bulwark_4", func_shelter_1f_bulwark_8017E2A4);
+#include <psyq/libgte.h>
+
+#include "gameplay/D4.h"
+#include "main/task.h"
+#include "rooms/room_common.h"
+
+extern s32     D_8011572C;
+extern s32     D_80115750;
+extern s32     D_80115758;
+extern SVECTOR D_shelter_1f_bulwark_80180378[];
+extern SVECTOR D_shelter_1f_bulwark_80180398[];
+
+void func_shelter_1f_bulwark_8017E2A4(Task* arg0)
+{
+    u8 view;
+
+    if (arg0->state == 0) {
+        D_80115758  = 0x601C2;
+        D_8011572C  = 0x601C3;
+        D_80115750  = 0x601C4;
+        arg0->state = 1;
+    }
+
+    view = Gp_GetViewIndex();
+    switch (view) {
+        case 2: {
+            SVECTOR* p = D_shelter_1f_bulwark_80180378;
+            Room_Draw29(&p[0], 0x300, 0x210);
+            Room_Draw29(&p[1], 0x300, 0x210);
+            Room_Draw29(&p[2], 0x300, 0x111);
+            Room_Draw29(&p[3], 0x300, 0x111);
+            break;
+        }
+        case 3:
+            Room_Draw29(&D_shelter_1f_bulwark_80180398[0], 0x200, 0x200);
+            break;
+    }
+}

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,3 +120,4 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_shelter_1f_airlock_8017D8A8 11 98.783
 func_shelter_1f_tent_8017FCA0 1 55.556
+func_shelter_1f_bulwark_8017D7B4 2 53.871


### PR DESCRIPTION
Matches two `shelter_1f_bulwark` functions:

- **`func_shelter_1f_bulwark_8017DE04`** — boot-save state machine (`Mc_SaveData`
  fields 5-8, `Fs_BeginBootLoad`, `Task_Spawn`/`Task_Kill`). Match needed dropping
  an aliasing `Task* task = arg0` local so GCC copies `arg0`→`s1` in the prologue
  instead of a branch delay slot (added as a DECOMPILATION_LEARNINGS.md entry).
- **`func_shelter_1f_bulwark_8017E2A4`** — view-index draw dispatch: one-shot
  `state==0` init of the `D_8011572C/50/58` globals, then `switch(Gp_GetViewIndex())`
  drawing the `D_80180378` strip / `D_80180398` via `Room_Draw29`.

Verified with unscoped `./tools/build-and-verify.sh` — `SLUS_010.42: OK`, all 437
matched functions still C.

The remaining three stubs (`8017D61C`, `8017D7B4`, `8017DA60`) are left for a
focused pass: all three are `switch(state)` machines whose compiler jump tables
share the single leading-rodata block of the base unit, so they need the
`units`+`rodata` manifest cut applied to all three together.
