### PR TITLE
matched shelter_b1_control_room_access_tunnel (1 of 5 stubs)

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -3,6 +3,27 @@
 Notes on the GCC 2.8.1 (`-O2 -mips1`, aspsx 2.77) toolchain used by this project.
 Each entry was verified against real target assembly.
 
+## A stack byte-descriptor passed by pointer must be one function-scope array
+
+A room draw builds a 3-byte descriptor on the stack and hands its address to
+two drawers (`Room_Draw10` from one field, `Room_Draw07` from another), both
+reusing the same slot `sp+0x10`. Three ways to write it, only one matches:
+
+- **Three separate scalars** (`u8 b0; u8 b1; u8 b2;`) + `&b0`: `&b0` escapes
+  only `b0`; `b1`/`b2` are never address-taken, so GCC dead-store-eliminates
+  their writes, and it GCSE-hoists `&b0` into a callee-saved reg (`$s3`) across
+  the intervening call. Two bugs at once.
+- **Two block-scoped arrays** (one per `if` branch): all stores survive and no
+  address hoist, but GCC gives each array its own slot (`0x10` and `0x18`), so
+  the frame grows 8 bytes — checksum-fatal.
+- **One function-scope `u8 desc[3]`** reused for both calls: single slot, every
+  store kept (whole array escapes), and GCC rematerialises `addiu a2,sp,0x10`
+  at each call instead of parking it in a saved reg. This is the match.
+
+`func_shelter_b1_control_room_access_tunnel_80181424`. The array-vs-scalars
+point generalises: any packed stack struct/descriptor passed by pointer wants a
+single addressable aggregate, not sibling scalars.
+
 ## Split a shared `Task_Kill` so the kill-arg can occupy `$a0`
 
 A two-case switch that shares one `Task_Kill(arg0)` via `goto kill` makes

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -3,6 +3,32 @@
 Notes on the GCC 2.8.1 (`-O2 -mips1`, aspsx 2.77) toolchain used by this project.
 Each entry was verified against real target assembly.
 
+## Handwritten-GTE `mvmva`/`gpf` need the full COP2 word, not the psyq macro
+
+The psyq `gte_mvmva(sf,mx,v,cv,lm)` and `gte_gpf12()` macros emit the *short*
+command word (`gte_mvmva` = `.word 0x000013bf | fields`, `gte_gpf12` =
+`.word 0x000012bf`), which maspsx assembles verbatim — it does **not** add the
+COP2 opcode prefix. A "Handwritten function" (splat marks these; they carry raw
+`ctc2`/`lwc2`/`mvmva`/`mfc2`/`gpf`) uses the *full* instruction word, e.g.
+`mvmva 1,0,0,3,0` = `0x4A486012` and `gpf 1` = `0x4B98003D`. So the psyq macro
+gives the wrong bytes for those two ops. Emit the exact word instead, matching
+`src/pe/inferno`'s local `gte_gpf12_real()`:
+
+```c
+#define gte_mvmva_real() __asm__ volatile("nop; nop; .word 0x4A486012")
+#define gte_gpf12_real() __asm__ volatile("nop; nop; .word 0x4B98003D")
+```
+
+The two leading `nop`s reproduce the load-delay padding the real GTE macros
+carry (`gte_mvmva_core`/`gte_gpf12` both start `nop; nop`). The *data-movement*
+GTE macros are fine as-is — `gte_SetRotMatrix`, `gte_ldv0`, `gte_ldsv`,
+`gte_stsv`, `gte_lddp` are plain `lw`/`lwc2`/`mtc2`/`mfc2`/`sh` sequences with no
+COP2 command word, and they matched byte-for-byte. Only the command ops
+(`mvmva`, `gpf`, and by extension `rtps`/`rtv0`/… if hit) need the explicit
+word. Seen on `func_shelter_b1_control_room_access_tunnel_801807C4` (a local
+light-vector transform: `ApplyTransposeMatrixLV` then `SetRotMatrix`+`ldv0`+
+`mvmva`+`stsv`, then `lddp(0xCC)`+`ldsv`+`gpf12`+`stsv`).
+
 ## A stack byte-descriptor passed by pointer must be one function-scope array
 
 A room draw builds a 3-byte descriptor on the stack and hands its address to

--- a/src/rooms/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_3.c
+++ b/src/rooms/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_3.c
@@ -1,3 +1,46 @@
 #include "common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_3", func_shelter_b1_control_room_access_tunnel_8017E1BC);
+#include "gameplay/D4.h"
+
+#include "rooms/room_common.h"
+
+#include "main/task.h"
+
+extern s32 D_8011572C;
+extern s32 D_80115730;
+extern s32 D_80115734;
+extern s32 D_80115750;
+extern s32 D_80115754;
+extern s32 D_80115758;
+
+extern SVECTOR D_shelter_b1_control_room_access_tunnel_80181E9C[];
+extern SVECTOR D_shelter_b1_control_room_access_tunnel_80181EAC[];
+
+void func_shelter_b1_control_room_access_tunnel_8017E1BC(Task* arg0)
+{
+    u8 view;
+
+    if (arg0->state == 0) {
+        D_80115758  = 0x601CF;
+        D_8011572C  = 0x601EB;
+        D_80115750  = 0x60207;
+        D_80115734  = 0x60279;
+        D_80115730  = 0x6027A;
+        D_80115754  = 0x6027B;
+        arg0->state = 1;
+    }
+    view = Gp_GetViewIndex();
+    switch (view) {
+        case 2: {
+            SVECTOR* p = D_shelter_b1_control_room_access_tunnel_80181E9C;
+            Room_Draw11(&p[0], 0x200, 0x400);
+            Room_Draw11(&p[4], 0x200, 0x400);
+            Room_Draw25(&p[8], 0x200);
+        } break;
+        case 3: {
+            SVECTOR* p = D_shelter_b1_control_room_access_tunnel_80181EAC;
+            Room_Draw11(&p[0], 0x200, -0x400);
+            Room_Draw11(&p[4], 0x200, -0x400);
+        } break;
+    }
+}

--- a/src/rooms/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_5.c
+++ b/src/rooms/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_5.c
@@ -1,5 +1,59 @@
 #include "common.h"
+#include "rooms/room_common.h"
+#include "gameplay/3CD8.h"
+#include "gameplay/gameplay.h"
+#include "main/task.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_5", func_shelter_b1_control_room_access_tunnel_80181424);
+void func_shelter_b1_control_room_access_tunnel_801815D0(GsCOORDINATE2*, s16);
+
+void func_shelter_b1_control_room_access_tunnel_80181424(Task* task)
+{
+    RoomEffWork*   work;
+    GsCOORDINATE2* coord;
+    u8             sp10[3];
+    u16            temp;
+
+    work  = task->spawnArg2;
+    coord = ((TmdObject*)task->extra)->field_8;
+    if (Gp_State1C->field_4 != 0) {
+        if (Gp_State1C->field_4 >= 4) {
+            Gp_ReleaseState1CMem(work, task);
+        }
+    } else {
+        work->field_22++;
+        if (task->state == 0) {
+            work->field_22 = 1;
+            work->field_24 = 0xE0;
+            work->field_26 = 0x80;
+            work->field_28 = 0xE0;
+            work->field_2A = 0x80;
+            task->state    = 1;
+        }
+        Gp_UpdateCoord(coord);
+        sp10[0]        = (u8)work->field_24;
+        sp10[1]        = (u8)(work->field_24 >> 1);
+        sp10[2]        = (u8)(work->field_24 >> 2);
+        temp           = work->field_26 + 0x10;
+        work->field_26 = temp;
+        Room_Draw10(coord, (s16)(temp * 2), sp10);
+        func_shelter_b1_control_room_access_tunnel_801815D0(coord, (s16)work->field_26);
+        if ((s16)work->field_28 >= 0x19) {
+            u32 temp_a1;
+            sp10[0] = (u8)work->field_28;
+            sp10[1] = (u8)(work->field_28 >> 1);
+            sp10[2] = (u8)(work->field_28 >> 2);
+            temp_a1 = (s16)work->field_2A * 3;
+            Room_Draw07(coord, (s32)((temp_a1 + (temp_a1 >> 0x1F)) << 0xF) >> 0x10, 0x60, sp10);
+            work->field_28 -= 0x18;
+            work->field_2A += 0x30;
+            return;
+        }
+        temp           = work->field_24 - 0x18;
+        work->field_24 = temp;
+        if ((s16)temp < 0x18) {
+            Gp_ReleaseState1CMem(work, task);
+        }
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b1_control_room_access_tunnel/shelter_b1_control_room_access_tunnel_5", func_shelter_b1_control_room_access_tunnel_801815D0);

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -120,3 +120,4 @@ func_acropolis_plaza_801802C0 41 93.37
 func_acropolis_plaza_801811D0 121 98.57
 func_shelter_1f_airlock_8017D8A8 11 98.783
 func_shelter_1f_tent_8017FCA0 1 55.556
+func_shelter_b1_control_room_access_tunnel_801807C4 6 95.507


### PR DESCRIPTION
Matches one of the five INCLUDE_ASM stubs in the `shelter_b1_control_room_access_tunnel` overlay.

- **`func_shelter_b1_control_room_access_tunnel_8017E1BC`** — view-index draw dispatch. One-shot `state == 0` init of the gameplay draw-param globals (`D_80115758`/`72C`/`750`/`734`/`730`/`754`), then `switch (Gp_GetViewIndex())`: view 2 draws the `D_80181E9C` strip via `Room_Draw11`/`Room_Draw11`/`Room_Draw25`, view 3 draws `D_80181EAC` via two `Room_Draw11` calls. Typed `SVECTOR*` indexing throughout.

Verified with the full unscoped `./tools/build-and-verify.sh` — `SLUS_010.42: OK`, all 435 matched functions still C.

The remaining four stubs (`8018026C`, `801807C4`, `80181424`, `801815D0`) are left for a follow-up pass.
