### PR TITLE
matched func_shelter_b1_golem_freezer_1_8017D624

### DIFF
--- a/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1.c
+++ b/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1.c
@@ -1,6 +1,16 @@
 #include "common.h"
+#include "main/session.h"
+#include "rooms/room_common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1", func_shelter_b1_golem_freezer_1_8017D624);
+extern void func_80131E70(void);
+
+s32 func_shelter_b1_golem_freezer_1_8017D624(s32 arg0, s32 arg1, RoomEventMsg* msg)
+{
+    if (msg->field_2 == 1 && Game_Session->field_9 == 0x15) {
+        func_80131E70();
+    }
+    return 0;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1", func_shelter_b1_golem_freezer_1_8017D66C);
 


### PR DESCRIPTION
Matches `func_shelter_b1_golem_freezer_1_8017D624` in the shelter_b1_golem_freezer_1 room overlay.

Room event handler: on event msg->field_2 == 1 with Game_Session->field_9 == 0x15, calls func_80131E70; returns 0 otherwise.

Verified: `./tools/build-and-verify.sh` -> `SLUS_010.42: OK` (full unscoped, 518 matched functions still C).