### PR TITLE
matched func_shelter_b6_training_room_8017D940

### DIFF
--- a/src/rooms/shelter_b6_training_room/shelter_b6_training_room_3.c
+++ b/src/rooms/shelter_b6_training_room/shelter_b6_training_room_3.c
@@ -1,3 +1,11 @@
 #include "common.h"
+#include "main/task.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b6_training_room/shelter_b6_training_room_3", func_shelter_b6_training_room_8017D940);
+#include "rooms/rooms_shared_801807d4.h"
+
+extern TaskDesc D_shelter_b6_training_room_801839A8;
+
+void func_shelter_b6_training_room_8017D940(void)
+{
+    RoomsShared801807d4Task = Task_SpawnFromTable(&D_shelter_b6_training_room_801839A8, 0, 0, 0);
+}


### PR DESCRIPTION
Matches `func_shelter_b6_training_room_8017D940` in the shelter_b6_training_room overlay.

Spawns the room's task table entry and stores the returned task in the shared `RoomsShared801807d4Task` slot:

```c
void func_shelter_b6_training_room_8017D940(void)
{
    RoomsShared801807d4Task = Task_SpawnFromTable(&D_shelter_b6_training_room_801839A8, 0, 0, 0);
}
```

Full build verified matching (SLUS_010.42 OK).