### PR TITLE
shelter_b1_golem_freezer_1: match two room-task functions

### DIFF
--- a/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1.c
+++ b/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1.c
@@ -1,8 +1,16 @@
 #include "common.h"
+
+#include "gameplay/D4.h"
+
 #include "main/session.h"
+#include "main/task.h"
 #include "rooms/room_common.h"
 
+extern GpMsgEntry D_shelter_b1_golem_freezer_1_8017E6A8[];
+
 extern void func_80131E70(void);
+extern void func_80131E24(void);
+void        func_shelter_b1_golem_freezer_1_8017D744(s32 arg0);
 
 s32 func_shelter_b1_golem_freezer_1_8017D624(s32 arg0, s32 arg1, RoomEventMsg* msg)
 {
@@ -12,7 +20,16 @@ s32 func_shelter_b1_golem_freezer_1_8017D624(s32 arg0, s32 arg1, RoomEventMsg* m
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1", func_shelter_b1_golem_freezer_1_8017D66C);
+void func_shelter_b1_golem_freezer_1_8017D66C(Task* arg0)
+{
+    arg0->field_24 = D_shelter_b1_golem_freezer_1_8017E6A8;
+    Game_SetPtrSlot(arg0, 7);
+    if (Game_Session->field_9 == 0x15) {
+        func_80131E24();
+    }
+    func_shelter_b1_golem_freezer_1_8017D744(0);
+    arg0->state = arg0->state + 1;
+}
 
 INCLUDE_RODATA("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1", D_shelter_b1_golem_freezer_1_8017D5C0);
 

--- a/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1_2.c
+++ b/src/rooms/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1_2.c
@@ -1,6 +1,38 @@
 #include "common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1_2", func_shelter_b1_golem_freezer_1_8017D744);
+#include "gameplay/3CD8.h"
+
+#include "main/session.h"
+#include "main/task.h"
+#include "main/tmd.h"
+
+#include <psyq/libgs.h>
+
+extern s16 D_shelter_b1_golem_freezer_1_8017E6D0;
+extern s16 D_shelter_b1_golem_freezer_1_8017E6D2;
+
+void func_shelter_b1_golem_freezer_1_8017D7CC(GsCOORDINATE2* arg0, s16* arg1);
+
+void func_shelter_b1_golem_freezer_1_8017D744(void)
+{
+    Task* slot   = (Task*)Gp_LookupSlot4(0);
+    Task* task   = slot;
+    s32   isNull = (slot == NULL);
+
+    if (isNull) {
+        task = Game_GetPtrSlot(3);
+    }
+    if (slot != NULL) {
+        if (Game_Session->field_9 == 0x15) {
+            D_shelter_b1_golem_freezer_1_8017E6D2 = 0;
+        } else {
+            D_shelter_b1_golem_freezer_1_8017E6D2 = 0x2710;
+        }
+    } else {
+        D_shelter_b1_golem_freezer_1_8017E6D2 = 0x2710;
+    }
+    func_shelter_b1_golem_freezer_1_8017D7CC(((TmdObject*)task->extra)->field_8, &D_shelter_b1_golem_freezer_1_8017E6D0);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b1_golem_freezer_1/shelter_b1_golem_freezer_1_2", func_shelter_b1_golem_freezer_1_8017D7CC);
 

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -1,0 +1,1 @@
+func_shelter_b1_golem_freezer_1_8017DA7C 6 ~85%


### PR DESCRIPTION
Matches two functions in the `shelter_b1_golem_freezer_1` room overlay.

## Matched
- `func_shelter_b1_golem_freezer_1_8017D66C` — room task init: parks the room's `GpMsgEntry[]` dispatch table in `Task::field_24`, registers the task in pointer slot 7, runs the `Game_Session::field_9 == 0x15` intro hook, then steps state.
- `func_shelter_b1_golem_freezer_1_8017D744` — resolves the slot-4 task (falling back to `Game_GetPtrSlot(3)`), sets the room's timer work word from `Game_Session::field_9`, and forwards the task's `TmdObject` coordinate to `func_..._8017D7CC`. Needed a hoisted null-test temp so the original lookup stays in a callee-saved register across the fallback call.

## Not matched (left as INCLUDE_ASM)
- `func_shelter_b1_golem_freezer_1_8017DA7C` — normal C, but GCC 2.8.1 -O2 strength-reduces the `D_8017E738` spawn-loop index into a `+8` pointer induction variable while the target recomputes `(i+2)*8 + base` each iteration. Not reproducible from C after several source forms and a long decomp-permuter run; added to `tools/difficult_functions`.
- `func_..._8017D7CC`, `func_..._8017DFFC`, `func_..._8017E254` — handwritten GTE routines (raw `ctc2`/`lwc2`/`mvmva`/`mfc2`/`gpf` + `RotTransSV`/`VectorNormalSS`); not attempted here.

Full unscoped `build-and-verify.sh` passes (`build/USA/out/SLUS_010.42: OK`), all matched functions intact.
