### PR TITLE
Match more shelter_b3_dumping_hole leaves

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -60049,3 +60049,37 @@ third, so `lw $v0, 0x2C($a0)` issued after `lw $s4, 0x1C($a0)` instead of before
 it. Assigning `coord` ahead of `work` and `enemy` in the source restored the
 target's order; the loads have no dependency on each other, so LUID order
 decides.
+## An oversized body shifts overlay trailing data, faking a data-symbol %lo drift (shelter_b3_dumping_hole_8017FF14, 2026-09-10)
+
+Symptom: a decompiled overlay function fails checksum, and objdump/nm show
+*every* trailing-data symbol in the overlay linked 0xC above its `D_<addr>`
+name, so a `%lo(D_..)` reference in the new function points 0xC past the real
+data. It looks like a room data-split (`rodata`/`data` cut) bug. It is not:
+the overlay matched fine with the function still `INCLUDE_ASM`, so the data
+was correctly placed. The C body simply compiled longer than the original, and
+because rodata+trailing-data follow `.text` in the overlay image, the extra
+0xC pushed all of it up. Fix the body size, and the symbols (and the `%lo`)
+snap back.
+
+Here the bloat was an `if/else` that loaded the same global twice:
+`if (D_8007218A==1) x = D_80073BA9 + 1; else x = D_80073BA9 + 0x22;` emits two
+`lbu D_80073BA9` loads + a `j`/`nop`. GCC 2.8.1 loads the global once and picks
+the addend across a branch only for the fused form
+`x = D_80073BA9 + (D_8007218A==1 ? 1 : 0x22);` — three instructions
+(`bne; addiu (delay); addu`), matching retail and restoring the image size.
+
+Corollary: when a checksum diff presents as a whole-section address drift,
+count the new function's instructions against the `.s` (`, 0xNN` in the
+`nonmatching` header) before touching the split config.
+
+## Flip an s0/s1 saved-register assignment with a local `register … asm()` pin
+
+Same function: after fixing size, the only diff was state→s1/entity→s0 where
+retail had state→s0/entity→s1. GCC assigns saved regs by allocation priority
+(ref count / live length), so the more-referenced pseudo took s0. Pinning both
+locals — `register DumpingHoleState* s asm("s0") = …;`
+`register DumpingHoleEntity* e asm("s1") = s->field_1C;` — reproduced retail's
+prologue exactly (`sw s0; lw s0,state; … sw s1; lw s1,0x1C(s0)`). Residual on
+this one is unrelated: retail hoists the *entity reload* (`lw a3,0x1C(s0)`) up
+into the ternary's load-delay slot while loading `->field_24` late, a sched1
+split that source order does not control (left at ~98%, permuter candidate).

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -12,7 +12,7 @@ extern s16      D_shelter_b3_dumping_hole_8018809C;
 typedef struct {
     u8    pad_00[0x28];
     Task* field_28;
-    u8    pad_2C[0x4];
+    Task* field_2C;
     s16   field_30;
     s16   field_32;
     u8    pad_34[0x4];
@@ -136,7 +136,11 @@ void func_shelter_b3_dumping_hole_8017FE64(s32 arg0)
     Gp_DispatchMsg(p->field_28, 0x7D5, arg0, 0);
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FE9C);
+void func_shelter_b3_dumping_hole_8017FE9C(s32 arg0)
+{
+    DumpingHoleEntity* p = D_shelter_b3_dumping_hole_8018F4A8->field_1C;
+    Gp_DispatchMsg(p->field_2C, 0x7D5, arg0, 0);
+}
 
 void func_shelter_b3_dumping_hole_8017FED4(s16 arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4.c
@@ -1,7 +1,10 @@
 #include "common.h"
 
+#include "gameplay/3A34.h"
+#include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
 #include "main/fs.h"
+#include "main/session.h"
 #include "main/task.h"
 
 typedef struct {
@@ -10,6 +13,8 @@ typedef struct {
     u8    pad_84[0x8];
     s16   field_8C;
     s16   field_8E;
+    u8    pad_90[0xC];
+    u16   field_9C;
 } DumpingHoleEntity;
 
 typedef struct {
@@ -18,8 +23,18 @@ typedef struct {
 } DumpingHoleState;
 
 extern DumpingHoleState* D_shelter_b3_dumping_hole_8018F4AC;
+extern u16               D_801153F6;
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4", func_shelter_b3_dumping_hole_801818E0);
+void func_shelter_b3_dumping_hole_801818E0(void)
+{
+    DumpingHoleEntity* p = D_shelter_b3_dumping_hole_8018F4AC->field_1C;
+    if (p->field_9C == 0) {
+        Gp_ReleaseStateF0Add((GpObj20E*)Gp_LookupSlot4(0), 0x20);
+        D_801153F6              = 0;
+        Game_Session->field_69 |= 0x80;
+        p->field_9C             = 1;
+    }
+}
 
 void func_shelter_b3_dumping_hole_80181958(s32 arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4.c
@@ -1,11 +1,15 @@
 #include "common.h"
 
+#include "gameplay/D4.h"
 #include "main/fs.h"
+#include "main/task.h"
 
 typedef struct {
-    u8  pad_00[0x8C];
-    s16 field_8C;
-    s16 field_8E;
+    u8    pad_00[0x80];
+    Task* field_80;
+    u8    pad_84[0x8];
+    s16   field_8C;
+    s16   field_8E;
 } DumpingHoleEntity;
 
 typedef struct {
@@ -17,7 +21,11 @@ extern DumpingHoleState* D_shelter_b3_dumping_hole_8018F4AC;
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4", func_shelter_b3_dumping_hole_801818E0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_4", func_shelter_b3_dumping_hole_80181958);
+void func_shelter_b3_dumping_hole_80181958(s32 arg0)
+{
+    DumpingHoleEntity* p = D_shelter_b3_dumping_hole_8018F4AC->field_1C;
+    Gp_DispatchMsg(p->field_80, 0x3F3, arg0, 0);
+}
 
 void func_shelter_b3_dumping_hole_80181990(s16 arg0)
 {

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -4,3 +4,4 @@ func_actor_403100_8013480C 26 97.154
 func_shelter_b1_golem_freezer_1_8017DA7C 6 ~85%
 func_shelter_b1_golem_freezer_1_8017E254 5 ~87%
 func_actor_400600_80137840 30 98.837
+func_shelter_b3_dumping_hole_8017FF14 1 90

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -5,3 +5,4 @@ func_shelter_b1_golem_freezer_1_8017DA7C 6 ~85%
 func_shelter_b1_golem_freezer_1_8017E254 5 ~87%
 func_actor_400600_80137840 30 98.837
 func_shelter_b3_dumping_hole_8017FF14 1 90
+func_shelter_b3_dumping_hole_8017FF14 3 ~98%


### PR DESCRIPTION
Follow-up to #18 with three more matches in shelter_b3_dumping_hole:

- func_shelter_b3_dumping_hole_8017FE9C - Gp_DispatchMsg wrapper (msg 0x7D5, field_2C)
- func_shelter_b3_dumping_hole_80181958 - Gp_DispatchMsg wrapper (msg 0x3F3, field_80 of D_8018F4AC entity)
- func_shelter_b3_dumping_hole_801818E0 - one-shot init guard (Gp_LookupSlot4/Gp_ReleaseStateF0Add, Game_Session flag)

Structs kept minimal and local to each TU. Also marks func_shelter_b3_dumping_hole_8017FF14 difficult (~98%, instruction-scheduling wall) with two DECOMPILATION_LEARNINGS notes. Full build verified: SLUS_010.42 OK.