### PR TITLE
Match 4 more shelter_b3_dumping_hole leaves

### DIFF
--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -1,9 +1,11 @@
 #include "common.h"
 #include "gameplay/D4.h"
 #include "main/fs.h"
+#include "main/session.h"
 #include "main/task.h"
 extern TaskDesc D_shelter_b3_dumping_hole_80188C04;
 extern TaskDesc D_shelter_b3_dumping_hole_80188BC8;
+extern s16      D_shelter_b3_dumping_hole_8018809C;
 
 typedef struct {
     u8    pad_00[0x28];
@@ -45,7 +47,13 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017F820);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FB70);
+s16 func_shelter_b3_dumping_hole_8017FB70(void)
+{
+    if (Game_Session->field_5 == 2) {
+        return 0;
+    }
+    return D_shelter_b3_dumping_hole_8018809C;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FBA0);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -1,6 +1,8 @@
 #include "common.h"
 #include "gameplay/D4.h"
 #include "main/fs.h"
+#include "main/gameflow.h"
+#include "main/mem.h"
 #include "main/session.h"
 #include "main/task.h"
 extern TaskDesc D_shelter_b3_dumping_hole_80188C04;
@@ -18,7 +20,16 @@ typedef struct {
     s16   field_3A;
     u8    pad_3C[0xC];
     s16   field_48;
+    u8    pad_4A[0x2];
+    u16   field_4C;
 } DumpingHoleEntity;
+
+typedef struct {
+    u8  pad_0[0x2];
+    s16 r;
+    s16 g;
+    s16 b;
+} DumpingHoleFadeWork;
 
 typedef struct {
     u8                 pad_00[0x1C];
@@ -55,7 +66,43 @@ s16 func_shelter_b3_dumping_hole_8017FB70(void)
     return D_shelter_b3_dumping_hole_8018809C;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FBA0);
+void func_shelter_b3_dumping_hole_8017FBA0(Task* arg0)
+{
+    DumpingHoleFadeWork* fade;
+    DumpingHoleFadeWork* alloc;
+    DumpingHoleEntity*   ent;
+
+    ent  = D_shelter_b3_dumping_hole_8018F4A8->field_1C;
+    fade = (DumpingHoleFadeWork*)arg0->idMap;
+    if (ent->field_4C == 1) {
+        Task_Kill(arg0);
+        return;
+    }
+    switch (arg0->state) {
+        case 0:
+            alloc       = (DumpingHoleFadeWork*)Mem_Malloc(8, 0);
+            arg0->idMap = (TaskIdMap*)alloc;
+            if (alloc == NULL) {
+                Task_Kill(arg0);
+                return;
+            }
+            fade         = alloc;
+            fade->b      = 0xFF;
+            fade->g      = 0xFF;
+            fade->r      = 0xFF;
+            arg0->state += 1;
+            /* fallthrough */
+        case 1:
+            Fade_DrawOverlay((u8)fade->r, (u8)fade->g, (u8)fade->r, 2);
+            fade->r -= (u16)arg0->spawnArg1;
+            fade->g -= (u16)arg0->spawnArg1;
+            fade->b -= (u16)arg0->spawnArg1;
+            if (fade->r < 0) {
+                Task_Kill(arg0);
+            }
+            break;
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FCA0);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -14,6 +14,8 @@ typedef struct {
     u8    pad_34[0x4];
     s16   field_38;
     s16   field_3A;
+    u8    pad_3C[0xC];
+    s16   field_48;
 } DumpingHoleEntity;
 
 typedef struct {
@@ -60,7 +62,13 @@ void func_shelter_b3_dumping_hole_8017FD9C(s32 arg0, s32 arg1)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FE10);
+void func_shelter_b3_dumping_hole_8017FE10(s32 arg0)
+{
+    DumpingHoleEntity* p = D_shelter_b3_dumping_hole_8018F4A8->field_1C;
+    if (arg0 == 0) {
+        p->field_48 = 1;
+    }
+}
 
 void func_shelter_b3_dumping_hole_8017FE34(void)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -1,5 +1,20 @@
 #include "common.h"
 
+typedef struct {
+    u8  _pad0[0x4];
+    s16 field_4;
+} DumpingHoleEntity;
+
+typedef struct {
+    u8                 _pad0[0x1C];
+    DumpingHoleEntity* field_1C;
+} DumpingHoleState;
+
+typedef struct {
+    u8  _pad0[0x2];
+    u16 field_2;
+} DumpingHoleMsg;
+
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183144);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183198);
@@ -10,7 +25,13 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801833EC);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183530);
+void func_shelter_b3_dumping_hole_80183530(DumpingHoleState* arg0, s32 arg1, DumpingHoleMsg* arg2)
+{
+    DumpingHoleEntity* ent = arg0->field_1C;
+    if (arg2->field_2 == 4) {
+        ent->field_4 = arg2->field_2;
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183550);
 


### PR DESCRIPTION
Matches eight functions in shelter_b3_dumping_hole (all 1 attempt):

- func_shelter_b3_dumping_hole_80183530 - entity field setter gated on message field_2 == 4
- func_shelter_b3_dumping_hole_8017FE10 - sets entity field_48 when arg0 == 0
- func_shelter_b3_dumping_hole_8017FB70 - returns 0 or a global s16 based on Game_Session->field_5
- func_shelter_b3_dumping_hole_8017FBA0 - fade-out task state machine (Mem_Malloc work block, Fade_DrawOverlay, steps channels by spawnArg1, self-kill)
- func_shelter_b3_dumping_hole_8017D82C - message gate: on msg 0x12, spawn 0x17 or 0x12 via Gp_SpawnIfCapIdle depending on GameFlag nibble 0x11D
- func_shelter_b3_dumping_hole_80183024 - countdown tick: decrement spawnArg1, kill at <= 0, then call the per-frame sub
- func_shelter_b3_dumping_hole_80183144 - forwards to RoomsShared801830f0Sub and Display_InitModeObj
- func_shelter_b3_dumping_hole_8017FCF4 - spawns a child task, allocates and zeroes a 0x24 work block into its idMap, copies three fields from the arg

Structs kept minimal and local to each translation unit. Verified with a full unscoped build: SLUS_010.42 OK, all matched functions still C.