### PR TITLE
Match 11 more shelter_b3_dumping_hole functions

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -58844,6 +58844,28 @@ edit landed together with moving the `vz` load ahead of the `7D8`/`7CA` stores,
 and the pair took the function from 89.8% to 98.6% with every saved register
 fixed, so which of the two moved the allocation was not isolated.
 
+## A call between deriving `p = a->b` and re-using `a->b` reloads the expression: reference it inline post-call
+
+`func_shelter_b3_dumping_hole_8017E7DC` caches `extra = arg0->extra` (a saved
+reg `s2`) for `coord = extra->field_8` and `Tmd_AllocBuffers(extra)`, but the
+`extra->field_C = 0` store *after* an intervening `Mem_Set(work,…)` call comes
+out as a fresh `lw v0,0x2C(s4)` reload, not `sh zero,0xC(s2)`. GCC 2.8.1's CSE
+does not carry a memory load across a call: `arg0->extra` read before `Mem_Set`
+is invalidated, so a later reference reloads — even though the pointer is still
+sitting in a saved register. Match it by referencing the chain inline at that
+one use, `((TmdObject*)arg0->extra)->field_C = 0;`, and keeping the cached
+`extra` local for the uses that *do* reuse `s2`.
+
+The same function's `func_800D7A9C(extra, (VECTOR*)coord->workm.t, 0, 3)` tail
+is not a direct pass: retail copies `coord->workm.t[0..2]` into a stack `VECTOR`
+and passes `&v`, reloading `arg0->extra->field_8` for each element (each stack
+store kills the CSE of the next load) while the *first* reload's `a0` is shared
+with the call's first argument. Reproduce with an explicit `VECTOR v;`, a local
+`e2 = (TmdObject*)arg0->extra;` used for both `v.vx` and the call, and inline
+`((TmdObject*)arg0->extra)->field_8->workm.t[i]` for `v.vy`/`v.vz`. Passing
+`(VECTOR*)coord->workm.t` directly (the `room_util20` form) instead emits no
+stack copy and no reloads.
+
 ## Transposed rotation copied through two base registers: one inline-asm block
 
 `func_actor_503500_801437D0` transposes the player's `coord` rotation into a
@@ -59052,6 +59074,31 @@ The same function also shows why that pointer won `s0` over the work pointer:
 it had to be the loop's walking pointer itself. A separate `src = (s32*)p`
 copy left `p` with few refs and dropped it behind `work` in global priority
 (flow counts refs weighted by loop depth).
+
+## A stack buffer's base kept in a register for one field store: write that field through a pointer alias
+
+`func_shelter_b3_dumping_hole_80181430` fills a `s32 desc[5]` then passes
+`(s32)desc` to `Gp_DispatchMsg`. Retail materialises `addiu a1,sp,0x18`
+(`&desc`) in the ternary's `bne` delay slot and stores `desc[1]` via
+`sw v0,0x4(a1)`, keeping the other elements `sp`-relative — so the ternary is a
+full `bne / j` diamond (the delay slot is consumed by the address, not the
+value). Writing every element as `desc[i]=` collapses it: GCC addresses all
+five off `sp`, never needs a base register, and folds the ternary into
+`bne`+fall-through (no `j`). Force the base into a register by writing the one
+element through an aliased pointer:
+
+```c
+s32  desc[5];
+s32* p = desc;
+desc[0] = base + (flag == 1 ? 1 : 0x22);
+p[1]    = 1;              /* &desc kept in a reg, used once, then reused for the call arg */
+desc[2] = desc[3] = desc[4] = 0;
+Gp_DispatchMsg(slot, 0x3E8, (s32)desc, 0);
+```
+
+The single pointer-based store gives `&desc` enough of a reason to live in a
+register across the ternary; the address computation then claims the `bne`
+delay slot and the `j` reappears.
 
 ## `lui/addiu` base in the wrong one of two arg regs: hoist the index into a local so the base is emitted later
 

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -60083,3 +60083,31 @@ prologue exactly (`sw s0; lw s0,state; … sw s1; lw s1,0x1C(s0)`). Residual on
 this one is unrelated: retail hoists the *entity reload* (`lw a3,0x1C(s0)`) up
 into the ternary's load-delay slot while loading `->field_24` late, a sched1
 split that source order does not control (left at ~98%, permuter candidate).
+### A loop accumulator lands in a callee-saved reg by spanning a call, not by an `asm` pin
+**Symptom.** A `switch`-free counter loop (`for (i…) if (…) count++;` then
+`if (count == K)`) came out one instruction short: the accumulator sat in a
+call-clobbered temp (`a1`), so no second callee-saved reg was saved and the
+frame was `0x18` instead of retail's `0x20`.
+**Wrong fix.** `register s16 count asm("s0")` makes the frame right but the
+accumulator is dead after the compare, so GCC reuses the pinned reg as the
+sign-extend temp — `sll s0,s0,16; sra s0,s0,16; bne s0,v0` — while retail
+extends into a fresh temp and keeps the const in another (`sll v0,s0,16;
+sra v0,v0,16; li v1,K; bne v0,v1`). Same class as the "pinning makes the shift
+in-place" note above.
+**Fix.** Don't pin. Make the accumulator *span the function call* the loop sits
+after: initialise `count = 0;` **before** the call (e.g. the `func_x();` ahead of
+the loop), not after it. A value live across a call must occupy a callee-saved
+reg, so GCC parks `count` in `s0` on its own, pushes the argument to `s1`, grows
+the frame to `0x20`, and — because `count` is a real variable, not a pinned
+throwaway — reads it into a fresh temp for the `(s16)` compare. `func_shelter_b3_dumping_hole_801838A0`.
+
+### Inline a sign-extended `s16` param at its use instead of a hoisted local
+**Symptom.** Everything matched except the one-time `sll/sra` that sign-extends
+an `s16` parameter was scheduled two instructions too early — ahead of the loop
+preamble (`i=0`, the hoisted `li K` compare constant) instead of after it.
+**Cause.** Assigning `s32 target = arg2;` near the top makes GCC treat the
+extension as its own early statement, so it emits right after the first init.
+**Fix.** Drop the temp and use the parameter directly in the loop compare
+(`if (count == arg2)`). GCC still hoists the single extension out of the loop,
+but now schedules it *among* the other loop-invariants (after `i=0` and the
+compare constant), matching retail. `func_shelter_b3_dumping_hole_80183198`.

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole.c
@@ -1,8 +1,30 @@
 #include "common.h"
 #include "gameplay/3CD8.h"
 #include "main/gameflag.h"
+#include "main/session.h"
+#include "rooms/room_common.h"
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole", func_shelter_b3_dumping_hole_8017D760);
+extern s32 func_80179A04(RoomEventMsg* in, RoomEventMsg* out);
+extern s16 func_shelter_b3_dumping_hole_8017FB70(void);
+
+s32 func_shelter_b3_dumping_hole_8017D760(s32 arg0, s32 arg1, RoomEventMsg* in, RoomEventMsg* out)
+{
+    *out = *in;
+    func_80179A04(in, out);
+    if (in->msgId == 0x28) {
+        if (func_shelter_b3_dumping_hole_8017FB70() != 0) {
+            if (in->field_5 == 0) {
+                Gp_RunCapCmd1(0x16);
+            }
+            return 0;
+        }
+        if (in->field_5 == 0) {
+            out->field_3 = (u8)Game_Session->unknown_133[1] + 1;
+        }
+        return 1;
+    }
+    return 1;
+}
 
 s32 func_shelter_b3_dumping_hole_8017D82C(s32 arg0, s32 arg1, s32 arg2)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole.c
@@ -1,8 +1,16 @@
 #include "common.h"
+#include "gameplay/3CD8.h"
+#include "main/gameflag.h"
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole", func_shelter_b3_dumping_hole_8017D760);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole", func_shelter_b3_dumping_hole_8017D82C);
+s32 func_shelter_b3_dumping_hole_8017D82C(s32 arg0, s32 arg1, s32 arg2)
+{
+    if (arg2 == 0x12) {
+        Gp_SpawnIfCapIdle(GameFlag_GetNibble(0x11D) != 0 ? 0x12 : 0x17, 1);
+    }
+    return 0;
+}
 
 INCLUDE_RODATA("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole", D_shelter_b3_dumping_hole_8017D5C0);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_2.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_2.c
@@ -1,6 +1,24 @@
 #include "common.h"
 #include "main/task.h"
+#include "main/session.h"
+#include "main/gameflag.h"
+#include "gameplay/3CD8.h"
+
+typedef struct {
+    u8    _pad0[0x24];
+    void* field_24;
+    u8    _pad28[0x8];
+    s32   field_30;
+} DumpingHoleState;
+
 extern TaskDesc D_shelter_b3_dumping_hole_80189ADC;
+extern u8       D_shelter_b3_dumping_hole_80187574[];
+extern u8       D_shelter_b3_dumping_hole_8018B080[];
+extern u8       D_shelter_b3_dumping_hole_8018B428[];
+extern u8       D_shelter_b3_dumping_hole_8018F4A4;
+extern TaskDesc D_80164B78;
+
+void func_shelter_b3_dumping_hole_80183198(s16 arg0, s16 arg1, s16 arg2);
 
 s32 func_shelter_b3_dumping_hole_8017D870(void)
 {
@@ -8,4 +26,24 @@ s32 func_shelter_b3_dumping_hole_8017D870(void)
     return 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_2", func_shelter_b3_dumping_hole_8017D8A0);
+void func_shelter_b3_dumping_hole_8017D8A0(DumpingHoleState* arg0)
+{
+    arg0->field_24 = D_shelter_b3_dumping_hole_80187574;
+    Game_SetPtrSlot(arg0, 7);
+    func_shelter_b3_dumping_hole_80183198(0x180, 0, 0);
+    if (GameFlag_GetNibble(0x78) == 0) {
+        if (Game_Session->field_9 == 1) {
+            if (Game_Session->field_8 == 3) {
+                func_800E8634((s32)D_shelter_b3_dumping_hole_8018B080, 0,
+                              (s32)D_shelter_b3_dumping_hole_8018B428);
+            }
+            func_800E3FAC(0xA2, 0x21);
+            GameFlag_SetNibble(0x78, 1);
+        }
+    }
+    if (Game_Session->field_5 >= 2) {
+        Task_SpawnFromTable(&D_80164B78, 0, 0, 0);
+    }
+    arg0->field_30                    += 1;
+    D_shelter_b3_dumping_hole_8018F4A4 = 0;
+}

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -1,5 +1,8 @@
 #include "common.h"
+#include "gameplay/3A34.h"
+#include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
+#include "main/display.h"
 #include "main/fs.h"
 #include "main/gameflow.h"
 #include "main/mem.h"
@@ -214,7 +217,66 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8018098C);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_80181430);
+typedef struct {
+    u8    pad_00[0x80];
+    Task* field_80;
+    Task* field_84;
+    Task* field_88;
+    u8    pad_8C[0xA];
+    s16   field_96;
+} DumpingHoleEntity4;
+
+typedef struct {
+    u8                  pad_00[0x1C];
+    DumpingHoleEntity4* field_1C;
+} DumpingHoleState4;
+
+typedef struct {
+    u8  field_0;
+    u8  field_1;
+    s16 field_2;
+} DumpingHoleDesc7DA;
+
+extern DumpingHoleState4* D_shelter_b3_dumping_hole_8018F4AC;
+extern s16                D_shelter_b3_dumping_hole_8018F4B0;
+extern s8                 D_8007218A;
+extern u8                 D_80073BA9;
+
+void func_shelter_b3_dumping_hole_80181430(void)
+{
+    DumpingHoleEntity4* ent;
+    DumpingHoleDesc7DA  desc;
+    s32                 desc3[5];
+    s32*                p3;
+
+    ent = D_shelter_b3_dumping_hole_8018F4AC->field_1C;
+    Gp_SetOverrideVec(NULL);
+    if (ent->field_88 != NULL) {
+        Task_CallExit(ent->field_88);
+        ent->field_88 = NULL;
+    }
+    ent->field_96 = 1;
+    Gp_PulseState1C();
+
+    D_shelter_b3_dumping_hole_8018F4B0 = 0;
+    desc.field_0 = Game_Session->field_7;
+    desc.field_1 = Game_Session->field_6;
+    desc.field_2 = 0x13;
+    Gp_DispatchMsg((Task*)Game_GetPtrSlot(4), 0x7DA, (s32)&desc, 0x7DB);
+
+    Display_ClampField126(0);
+    Gp_DispatchMsg(ent->field_84, 0x7D5, 1, 0);
+    Gp_DispatchMsg(ent->field_80, 0x3F3, 1, 0);
+
+    p3       = desc3;
+    desc3[0] = D_80073BA9 + (D_8007218A == 1 ? 1 : 0x22);
+    p3[1]    = 1;
+    desc3[2] = 0;
+    desc3[3] = 0;
+    desc3[4] = 0;
+    Gp_DispatchMsg((Task*)Game_GetPtrSlot(3), 0x3E8, (s32)desc3, 0);
+    CdCmd_CancelReplaceAndActivate();
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_80181560);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -113,7 +113,36 @@ void func_shelter_b3_dumping_hole_8017FBA0(Task* arg0)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FCA0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FCF4);
+typedef struct {
+    u8  pad_00[0xC];
+    s16 field_C;
+    s16 field_E;
+    s16 field_10;
+} DumpingHoleSpawnWork;
+
+typedef struct {
+    u16 field_0;
+    u16 field_2;
+    u16 field_4;
+} DumpingHoleSpawnArg;
+
+void func_shelter_b3_dumping_hole_8017FCF4(Task* arg0, DumpingHoleSpawnArg* arg1)
+{
+    Task*                 task;
+    DumpingHoleSpawnWork* work;
+
+    task        = Task_SpawnFromTable(&D_shelter_b3_dumping_hole_80188C04, 1, 0, (s32)arg0);
+    work        = (DumpingHoleSpawnWork*)Mem_Malloc(0x24, 0);
+    task->idMap = (TaskIdMap*)work;
+    if (work == NULL) {
+        Task_Kill(task);
+        return;
+    }
+    Mem_Set(work, 0, 0x24);
+    work->field_C  = arg1->field_0;
+    work->field_E  = arg1->field_2;
+    work->field_10 = arg1->field_4;
+}
 
 void func_shelter_b3_dumping_hole_8017FD9C(s32 arg0, s32 arg1)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -2,12 +2,15 @@
 #include "gameplay/3A34.h"
 #include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
+#include "gameplay/gameplay.h"
 #include "main/display.h"
 #include "main/fs.h"
 #include "main/gameflow.h"
+#include "main/gfx.h"
 #include "main/mem.h"
 #include "main/session.h"
 #include "main/task.h"
+#include "main/tmd.h"
 extern TaskDesc D_shelter_b3_dumping_hole_80188C04;
 extern TaskDesc D_shelter_b3_dumping_hole_80188BC8;
 extern s16      D_shelter_b3_dumping_hole_8018809C;
@@ -58,7 +61,61 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017E440);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017E7DC);
+typedef struct {
+    s32 field_0;
+    s32 field_4;
+    s32 field_8;
+    u8  pad_C[0x4];
+    s16 field_10;
+    s16 field_12;
+    s16 field_14;
+} DumpingHoleCoordCfg;
+
+typedef struct {
+    MATRIX field_0;
+    MATRIX field_20;
+    u8     pad_40[0x1C];
+} DumpingHoleCoordWork;
+
+void func_shelter_b3_dumping_hole_8017E7DC(Task* arg0)
+{
+    DumpingHoleCoordWork*         work;
+    register TmdObject*           extra asm("s2");
+    GsCOORDINATE2*                coord;
+    register DumpingHoleCoordCfg* cfg asm("s3");
+    VECTOR                        v;
+    TmdObject*                    e2;
+
+    extra       = (TmdObject*)arg0->extra;
+    cfg         = (DumpingHoleCoordCfg*)arg0->spawnArg2;
+    coord       = extra->field_8;
+    work        = (DumpingHoleCoordWork*)Mem_Malloc(0x5C, 0);
+    arg0->idMap = (TaskIdMap*)work;
+    if (work == NULL) {
+        Task_Kill(arg0);
+        return;
+    }
+    Mem_Set(work, 0, 0x5C);
+    coord->sub                         = &Gfx_ViewCoord;
+    ((TmdObject*)arg0->extra)->field_C = 0;
+    Tmd_AllocBuffers(extra);
+    extra->field_1C   = &work->field_0;
+    extra->field_20   = &work->field_20;
+    coord->coord.t[0] = cfg->field_0;
+    coord->coord.t[1] = cfg->field_4;
+    coord->coord.t[2] = cfg->field_8;
+    Gfx_RotMatrixY(&coord->coord, cfg->field_12, 1);
+    Gfx_RotMatrixX(&coord->coord, cfg->field_10, 0);
+    Gfx_RotMatrixZ(&coord->coord, cfg->field_14, 0);
+    coord->flg = 0;
+    Task_Reparent((Task*)D_shelter_b3_dumping_hole_8018F4A8, arg0);
+    Gp_UpdateCoord(coord);
+    e2   = (TmdObject*)arg0->extra;
+    v.vx = e2->field_8->workm.t[0];
+    v.vy = ((TmdObject*)arg0->extra)->field_8->workm.t[1];
+    v.vz = ((TmdObject*)arg0->extra)->field_8->workm.t[2];
+    func_800D7A9C(e2, &v, 0, 3);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017E94C);
 
@@ -259,9 +316,9 @@ void func_shelter_b3_dumping_hole_80181430(void)
     Gp_PulseState1C();
 
     D_shelter_b3_dumping_hole_8018F4B0 = 0;
-    desc.field_0 = Game_Session->field_7;
-    desc.field_1 = Game_Session->field_6;
-    desc.field_2 = 0x13;
+    desc.field_0                       = Game_Session->field_7;
+    desc.field_1                       = Game_Session->field_6;
+    desc.field_2                       = 0x13;
     Gp_DispatchMsg((Task*)Game_GetPtrSlot(4), 0x7DA, (s32)&desc, 0x7DB);
 
     Display_ClampField126(0);

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -37,8 +37,15 @@ typedef struct {
 } DumpingHoleState;
 
 extern DumpingHoleState* D_shelter_b3_dumping_hole_8018F4A8;
+extern TaskFuncTable3    D_shelter_b3_dumping_hole_8017D5C4;
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017D9A8);
+void func_shelter_b3_dumping_hole_8017D9A8(Task* task)
+{
+    TaskFuncTable3 sp;
+
+    sp = D_shelter_b3_dumping_hole_8017D5C4;
+    sp.funcs[task->state](task);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017DA00);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -3,9 +3,12 @@
 #include "main/session.h"
 #include "main/task.h"
 #include "main/tmd.h"
+#include "main/pad.h"
+#include "main/stage.h"
 
 extern void func_shelter_b3_dumping_hole_8017FD9C(s32 arg0, s32 arg1);
 extern void func_shelter_b3_dumping_hole_8017FE10(void);
+extern void func_shelter_b3_dumping_hole_80181C8C(void);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181A48);
 
@@ -44,6 +47,12 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80182FD0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80183024);
+void func_shelter_b3_dumping_hole_80183024(Task* arg0)
+{
+    if ((arg0->spawnArg1 -= 1) <= 0) {
+        Task_Kill(arg0);
+    }
+    func_shelter_b3_dumping_hole_80181C8C();
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80183060);

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -6,6 +6,7 @@
 #include "main/pad.h"
 #include "main/stage.h"
 #include "gameplay/3CD8.h"
+#include "main/display.h"
 
 typedef struct {
     u8  field_0;
@@ -25,7 +26,37 @@ extern void func_shelter_b3_dumping_hole_80181C8C(void);
 void        func_shelter_b3_dumping_hole_80181F80(s32 arg0, s32 arg1, s32 arg2, s32 arg3);
 void        func_shelter_b3_dumping_hole_80182AA0(void);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181A48);
+typedef struct {
+    u8  pad_00[0x2A];
+    u16 field_2A;
+    u8  pad_2C[0x4];
+    s32 field_30;
+    s32 field_34;
+} Sub81A48;
+
+void func_shelter_b3_dumping_hole_80181A48(Task* arg0)
+{
+    Sub81A48* s = (Sub81A48*)arg0;
+
+    switch (s->field_30) {
+        case 0:
+            s->field_34  = 3;
+            s->field_2A  = 8;
+            s->field_30 += 1;
+            break;
+        case 1:
+            if ((s16)(s->field_2A -= 1) < 0) {
+                s->field_30 += 1;
+            }
+            Display_ClampField126(s->field_34);
+            s->field_34 = -s->field_34;
+            break;
+        default:
+            Display_ClampField126(0);
+            Task_Kill(arg0);
+            break;
+    }
+}
 
 void func_shelter_b3_dumping_hole_80181B04(s16 arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -5,10 +5,25 @@
 #include "main/tmd.h"
 #include "main/pad.h"
 #include "main/stage.h"
+#include "gameplay/3CD8.h"
+
+typedef struct {
+    u8  field_0;
+    u8  field_1;
+    u8  _pad2[0x2];
+    u8  field_4;
+    u8  _pad5[0x3];
+    s32 field_8;
+} DumpingHoleSpawnElem;
+
+extern DumpingHoleSpawnElem* D_shelter_b3_dumping_hole_8018F4BC;
+extern s16                   D_shelter_b3_dumping_hole_8018F4C6;
 
 extern void func_shelter_b3_dumping_hole_8017FD9C(s32 arg0, s32 arg1);
 extern void func_shelter_b3_dumping_hole_8017FE10(void);
 extern void func_shelter_b3_dumping_hole_80181C8C(void);
+void        func_shelter_b3_dumping_hole_80181F80(s32 arg0, s32 arg1, s32 arg2, s32 arg3);
+void        func_shelter_b3_dumping_hole_80182AA0(void);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181A48);
 
@@ -25,7 +40,27 @@ void func_shelter_b3_dumping_hole_80181B44(void)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181B64);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181C8C);
+void func_shelter_b3_dumping_hole_80181C8C(void)
+{
+    if (D_shelter_b3_dumping_hole_8018F4BC == NULL) {
+        return;
+    }
+    if (D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_8 == -1) {
+        return;
+    }
+    if (Gp_CapBusy() != 0) {
+        return;
+    }
+    func_shelter_b3_dumping_hole_80181F80(
+        D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_8, 0x80, 1,
+        D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_0 |
+            ((D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_1 & 0x10)
+             << 4));
+    if (D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_4 & 1) {
+        return;
+    }
+    func_shelter_b3_dumping_hole_80182AA0();
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181D68);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -55,4 +55,19 @@ void func_shelter_b3_dumping_hole_80183024(Task* arg0)
     func_shelter_b3_dumping_hole_80181C8C();
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80183060);
+void func_shelter_b3_dumping_hole_80183060(Task* arg0)
+{
+    switch (arg0->state) {
+        case 0:
+            arg0->state = 1;
+            break;
+        case 1:
+            arg0->spawnArg1 -= 1;
+            if (arg0->spawnArg1 <= 0 || Pad_CheckButtons(0, 1, Pad_MaskCancel) != 0) {
+                Task_Kill(arg0);
+                Stage_SetEndingFlag();
+            }
+            break;
+    }
+    func_shelter_b3_dumping_hole_80181C8C();
+}

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -121,7 +121,33 @@ void func_shelter_b3_dumping_hole_80183198(s16 arg0, s16 arg1, s16 arg2)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183218);
+typedef struct {
+    u8 _pad0[0xC];
+    u8 field_C;
+    u8 _pad2[0x7];
+    u8 field_14;
+} SprtViewState;
+
+typedef struct {
+    u8             _pad0[0xA0];
+    SprtViewState* field_A0;
+} SprtBigRec;
+
+void func_shelter_b3_dumping_hole_80183218(u8 arg0)
+{
+    GameSessionFrom4* g4 = (GameSessionFrom4*)&Game_Session->field_4;
+    SprtViewState*    vs =
+        ((SprtBigRec*)Gp_SprtTables[g4->field_3 - 1]->field_0[g4->field_2 - 1])->field_A0;
+
+    if (arg0 == 0) {
+        vs->field_C  = 1;
+        vs->field_14 = 1;
+    } else if (arg0 == 1) {
+        vs->field_14 = 0;
+    } else if (arg0 == 2) {
+        vs->field_C = 0;
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183298);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -72,7 +72,13 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183A00);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183A98);
+void func_shelter_b3_dumping_hole_80183A98(DumpingHoleState* arg0)
+{
+    if (arg0->field_1C->field_0->field_40 <= 0) {
+        D_shelter_b3_dumping_hole_8018B7BC[arg0->field_36].field_6 = 2;
+        Task_Kill((Task*)arg0);
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183AEC);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -6,6 +6,7 @@
 #include "gameplay/1BC.h"
 #include "main/mem.h"
 #include "main/fs.h"
+#include "main/display.h"
 
 typedef struct {
     u8 _pad0[0x24];
@@ -75,12 +76,19 @@ extern TaskDesc        D_80142604;
 extern TaskDesc        D_801575F0;
 extern s16             D_shelter_b3_dumping_hole_8018B578;
 extern s16             D_shelter_b3_dumping_hole_8018B57A;
+extern TaskDesc        D_shelter_b3_dumping_hole_8018B594;
+
+void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
 
 void func_shelter_b3_dumping_hole_801833EC(DumpingHoleState* arg0);
 void func_shelter_b3_dumping_hole_80183E6C(s16 arg0, s16 arg1, s16 arg2);
 void func_shelter_b3_dumping_hole_80181D68(s32 arg0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183144);
+void func_shelter_b3_dumping_hole_80183144(s16 arg0, s16 arg1, s16 arg2)
+{
+    RoomsShared801830f0Sub(arg0, arg1, 0xD0);
+    Display_InitModeObj(&D_shelter_b3_dumping_hole_8018B594, arg2, 0, 0);
+}
 
 void func_shelter_b3_dumping_hole_80183198(s16 arg0, s16 arg1, s16 arg2)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -2,10 +2,25 @@
 #include "main/task.h"
 #include "main/session.h"
 #include "gameplay/3A34.h"
+#include "gameplay/D4.h"
 
 typedef struct {
-    u8  _pad0[0x40];
-    s16 field_40;
+    u8 _pad0[0x24];
+    u8 field_24;
+    u8 field_25;
+} DumpingHoleP2C;
+
+typedef struct {
+    u8              _pad0[0x2C];
+    DumpingHoleP2C* field_2C;
+} DumpingHoleTarget2;
+
+typedef struct {
+    DumpingHoleTarget2* field_0;
+    u8                  _pad4[0x6];
+    s16                 field_A;
+    u8                  _pad0C[0x34];
+    s16                 field_40;
 } DumpingHoleTarget;
 
 typedef struct {
@@ -14,9 +29,16 @@ typedef struct {
 } DumpingHoleEntity;
 
 typedef struct {
+    DumpingHoleTarget* field_0;
+    u16                field_4;
+} DumpingHoleEntityB;
+
+typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
-    u8                 _pad20[0x16];
+    u8                 _pad20[0x10];
+    s32                field_30;
+    s16                field_34;
     s16                field_36;
 } DumpingHoleState;
 
@@ -29,6 +51,12 @@ typedef struct {
     u8  _pad0[0x6];
     s16 field_6;
 } DumpingHoleB7BC;
+
+typedef struct {
+    u8  field_0;
+    u8  field_1;
+    u16 field_2;
+} DumpingHoleDispatchDesc;
 
 extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
 
@@ -89,7 +117,25 @@ void func_shelter_b3_dumping_hole_801838A0(DumpingHoleState* arg0)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183950);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183A00);
+void func_shelter_b3_dumping_hole_80183A00(DumpingHoleState* arg0)
+{
+    DumpingHoleDispatchDesc desc;
+    DumpingHoleEntityB*     ent = (DumpingHoleEntityB*)arg0->field_1C;
+    DumpingHoleTarget*      t0  = ent->field_0;
+    DumpingHoleTarget2*     t00 = t0->field_0;
+
+    if ((s16)(ent->field_4 += 1) >= 0x2E) {
+        DumpingHoleP2C* p = t00->field_2C;
+        p->field_25       = 2;
+        p->field_24       = 0;
+        t0->field_A       = 0x900;
+        desc.field_0      = 0;
+        desc.field_1      = 0x2C;
+        desc.field_2      = arg0->field_34;
+        Gp_DispatchMsg((Task*)t00, 0x7DB, (s32)&desc, 0);
+        arg0->field_30 += 1;
+    }
+}
 
 void func_shelter_b3_dumping_hole_80183A98(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -79,6 +79,7 @@ extern s16             D_shelter_b3_dumping_hole_8018B57A;
 extern TaskDesc        D_shelter_b3_dumping_hole_8018B594;
 extern TaskFuncTable4  D_shelter_b3_dumping_hole_8017D654;
 extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D664;
+extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D670;
 extern u8              D_801153F4;
 
 void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
@@ -144,7 +145,13 @@ void func_shelter_b3_dumping_hole_801835C8(Task* task)
     sp.funcs[task->state](task);
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183620);
+void func_shelter_b3_dumping_hole_80183620(Task* task)
+{
+    TaskFuncTable3 sp;
+
+    sp = D_shelter_b3_dumping_hole_8017D670;
+    sp.funcs[task->state](task);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183678);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -66,7 +66,26 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183824);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801838A0);
+void func_shelter_b3_dumping_hole_801838A0(DumpingHoleState* arg0)
+{
+    s16 count;
+    s32 i;
+
+    count = 0;
+    if (arg0->field_1C->field_4 != 4) {
+        func_shelter_b3_dumping_hole_801833EC(arg0);
+        for (i = 0; i < 0x10; i++) {
+            if (D_shelter_b3_dumping_hole_8018B7BC[i].field_6 == 2) {
+                count++;
+            }
+        }
+        if (count == 0x10) {
+            ((void (*)(Task*, s32))Gp_ReleaseStateF0Clear)((Task*)arg0, 0);
+            Game_Session->unknown_130[0] = 2;
+            Task_Kill((Task*)arg0);
+        }
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183950);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -46,7 +46,9 @@ typedef struct {
 typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
-    u8                 _pad20[0x10];
+    u8                 _pad20[0x4];
+    void*              field_24;
+    u8                 _pad28[0x8];
     s32                field_30;
     s16                field_34;
     s16                field_36;
@@ -82,6 +84,7 @@ extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D664;
 extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D670;
 extern TaskFuncTable5  D_shelter_b3_dumping_hole_8017D67C;
 extern u8              D_801153F4;
+extern u8              D_shelter_b3_dumping_hole_8018B7AC[];
 
 void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
 
@@ -162,7 +165,28 @@ void func_shelter_b3_dumping_hole_80183678(Task* task)
     sp.funcs[task->state](task);
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801836E0);
+void func_shelter_b3_dumping_hole_801836E0(DumpingHoleState* arg0)
+{
+    DumpingHoleEntity* work;
+    s32                i;
+
+    if ((u8)Game_Session->unknown_130[0] == 2) {
+        Task_Kill((Task*)arg0);
+        return;
+    }
+    work = Mem_Calloc(6, 0);
+    if (work == NULL) {
+        Task_Kill((Task*)arg0);
+        return;
+    }
+    for (i = 15; i >= 0; i--) {
+        D_shelter_b3_dumping_hole_8018B7BC[i].field_6 = 0;
+    }
+    D_shelter_b3_dumping_hole_8018F4D4 = 0;
+    arg0->field_1C                     = work;
+    arg0->field_24                     = D_shelter_b3_dumping_hole_8018B7AC;
+    arg0->field_30 += 1;
+}
 
 void func_shelter_b3_dumping_hole_8018378C(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -80,6 +80,7 @@ extern TaskDesc        D_shelter_b3_dumping_hole_8018B594;
 extern TaskFuncTable4  D_shelter_b3_dumping_hole_8017D654;
 extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D664;
 extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D670;
+extern TaskFuncTable5  D_shelter_b3_dumping_hole_8017D67C;
 extern u8              D_801153F4;
 
 void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
@@ -153,7 +154,13 @@ void func_shelter_b3_dumping_hole_80183620(Task* task)
     sp.funcs[task->state](task);
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183678);
+void func_shelter_b3_dumping_hole_80183678(Task* task)
+{
+    TaskFuncTable5 sp;
+
+    sp = D_shelter_b3_dumping_hole_8017D67C;
+    sp.funcs[task->state](task);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801836E0);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -78,6 +78,7 @@ extern s16             D_shelter_b3_dumping_hole_8018B578;
 extern s16             D_shelter_b3_dumping_hole_8018B57A;
 extern TaskDesc        D_shelter_b3_dumping_hole_8018B594;
 extern TaskFuncTable4  D_shelter_b3_dumping_hole_8017D654;
+extern TaskFuncTable3  D_shelter_b3_dumping_hole_8017D664;
 extern u8              D_801153F4;
 
 void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
@@ -135,7 +136,13 @@ void func_shelter_b3_dumping_hole_80183550(Task* task)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801835C8);
+void func_shelter_b3_dumping_hole_801835C8(Task* task)
+{
+    TaskFuncTable3 sp;
+
+    sp = D_shelter_b3_dumping_hole_8017D664;
+    sp.funcs[task->state](task);
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183620);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -3,6 +3,9 @@
 #include "main/session.h"
 #include "gameplay/3A34.h"
 #include "gameplay/D4.h"
+#include "gameplay/1BC.h"
+#include "main/mem.h"
+#include "main/fs.h"
 
 typedef struct {
     u8 _pad0[0x24];
@@ -17,7 +20,8 @@ typedef struct {
 
 typedef struct {
     DumpingHoleTarget2* field_0;
-    u8                  _pad4[0x6];
+    u8                  _pad4[0x4];
+    s16                 field_8;
     s16                 field_A;
     u8                  _pad0C[0x34];
     s16                 field_40;
@@ -34,6 +38,11 @@ typedef struct {
 } DumpingHoleEntityB;
 
 typedef struct {
+    u8  _pad0[0x2];
+    s16 field_2;
+} DumpingHoleEntityC;
+
+typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
     u8                 _pad20[0x10];
@@ -48,7 +57,9 @@ typedef struct {
 } DumpingHoleMsg;
 
 typedef struct {
-    u8  _pad0[0x6];
+    s16 field_0;
+    s16 field_2;
+    u8  _pad4[0x2];
     s16 field_6;
 } DumpingHoleB7BC;
 
@@ -59,8 +70,15 @@ typedef struct {
 } DumpingHoleDispatchDesc;
 
 extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
+extern u16             D_shelter_b3_dumping_hole_8018F4D4;
+extern TaskDesc        D_80142604;
+extern TaskDesc        D_801575F0;
+extern s16             D_shelter_b3_dumping_hole_8018B578;
+extern s16             D_shelter_b3_dumping_hole_8018B57A;
 
 void func_shelter_b3_dumping_hole_801833EC(DumpingHoleState* arg0);
+void func_shelter_b3_dumping_hole_80183E6C(s16 arg0, s16 arg1, s16 arg2);
+void func_shelter_b3_dumping_hole_80181D68(s32 arg0);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183144);
 
@@ -90,7 +108,19 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801836E0);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_8018378C);
+void func_shelter_b3_dumping_hole_8018378C(DumpingHoleState* arg0)
+{
+    DumpingHoleEntityC* ent = (DumpingHoleEntityC*)arg0->field_1C;
+    s32                 i;
+
+    for (i = 0; i < 3; i++) {
+        s16 idx = ent->field_2;
+        func_shelter_b3_dumping_hole_80183E6C(idx, D_shelter_b3_dumping_hole_8018B7BC[idx].field_0,
+                                              D_shelter_b3_dumping_hole_8018B7BC[idx].field_2);
+        ent->field_2 += 1;
+    }
+    arg0->field_30 += 1;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183824);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -147,7 +147,25 @@ void func_shelter_b3_dumping_hole_80183A98(DumpingHoleState* arg0)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183AEC);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183B9C);
+void func_shelter_b3_dumping_hole_80183B9C(DumpingHoleState* arg0)
+{
+    DumpingHoleDispatchDesc desc;
+    DumpingHoleEntityB*     ent = (DumpingHoleEntityB*)arg0->field_1C;
+    DumpingHoleTarget*      t0  = ent->field_0;
+    DumpingHoleTarget2*     t00 = t0->field_0;
+
+    if ((s16)(ent->field_4 += 1) >= 0x3D) {
+        DumpingHoleP2C* p = t00->field_2C;
+        p->field_24       = 2;
+        p->field_25       = 4;
+        t0->field_A       = 0x900;
+        desc.field_0      = 0;
+        desc.field_1      = 0x2A;
+        desc.field_2      = arg0->field_34;
+        Gp_DispatchMsg((Task*)t00, 0x7DB, (s32)&desc, 0);
+        arg0->field_30 += 1;
+    }
+}
 
 void func_shelter_b3_dumping_hole_80183C38(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -1,19 +1,38 @@
 #include "common.h"
+#include "main/task.h"
+#include "main/session.h"
+#include "gameplay/3A34.h"
 
 typedef struct {
-    u8  _pad0[0x4];
-    s16 field_4;
+    u8  _pad0[0x40];
+    s16 field_40;
+} DumpingHoleTarget;
+
+typedef struct {
+    DumpingHoleTarget* field_0;
+    s16                field_4;
 } DumpingHoleEntity;
 
 typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
+    u8                 _pad20[0x16];
+    s16                field_36;
 } DumpingHoleState;
 
 typedef struct {
     u8  _pad0[0x2];
     u16 field_2;
 } DumpingHoleMsg;
+
+typedef struct {
+    u8  _pad0[0x6];
+    s16 field_6;
+} DumpingHoleB7BC;
+
+extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
+
+void func_shelter_b3_dumping_hole_801833EC(DumpingHoleState* arg0);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183144);
 
@@ -59,4 +78,10 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183B9C);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183C38);
+void func_shelter_b3_dumping_hole_80183C38(DumpingHoleState* arg0)
+{
+    if (arg0->field_1C->field_0->field_40 <= 0) {
+        D_shelter_b3_dumping_hole_8018B7BC[arg0->field_36].field_6 = 2;
+        Task_Kill((Task*)arg0);
+    }
+}

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -194,7 +194,26 @@ void func_shelter_b3_dumping_hole_80183A98(DumpingHoleState* arg0)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183AEC);
+void func_shelter_b3_dumping_hole_80183AEC(DumpingHoleState* arg0)
+{
+    DumpingHoleEntity* work = Mem_Calloc(8, 0);
+    if (work != NULL) {
+        DumpingHoleTarget* enemy;
+        arg0->field_1C = work;
+        enemy          = (DumpingHoleTarget*)Gp_SpawnEnemyFromTable(&D_801575F0, 2, 0, NULL);
+        if (enemy != NULL) {
+            u16 idx;
+            D_shelter_b3_dumping_hole_8018B7BC[arg0->field_36].field_6 = 1;
+            idx                                                        = D_shelter_b3_dumping_hole_8018F4D4;
+            work->field_0                                              = enemy;
+            enemy->field_8                                             = idx << 12;
+            D_shelter_b3_dumping_hole_8018F4D4                         = idx + 1;
+            arg0->field_30 += 1;
+            return;
+        }
+    }
+    Task_Kill((Task*)arg0);
+}
 
 void func_shelter_b3_dumping_hole_80183B9C(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -77,6 +77,8 @@ extern TaskDesc        D_801575F0;
 extern s16             D_shelter_b3_dumping_hole_8018B578;
 extern s16             D_shelter_b3_dumping_hole_8018B57A;
 extern TaskDesc        D_shelter_b3_dumping_hole_8018B594;
+extern TaskFuncTable4  D_shelter_b3_dumping_hole_8017D654;
+extern u8              D_801153F4;
 
 void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
 
@@ -123,7 +125,15 @@ void func_shelter_b3_dumping_hole_80183530(DumpingHoleState* arg0, s32 arg1, Dum
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183550);
+void func_shelter_b3_dumping_hole_80183550(Task* task)
+{
+    TaskFuncTable4 sp;
+
+    sp = D_shelter_b3_dumping_hole_8017D654;
+    if (D_801153F4 == 0) {
+        sp.funcs[task->state](task);
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_801835C8);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -82,7 +82,24 @@ void func_shelter_b3_dumping_hole_80181D68(s32 arg0);
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183144);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183198);
+void func_shelter_b3_dumping_hole_80183198(s16 arg0, s16 arg1, s16 arg2)
+{
+    s32 count;
+    s32 i;
+
+    count                              = 0;
+    D_shelter_b3_dumping_hole_8018B578 = arg0;
+    D_shelter_b3_dumping_hole_8018B57A = arg1;
+    for (i = 0; i < 0x32; i++) {
+        if (D_8006C338[i].field_0 == 3) {
+            if (count == arg2) {
+                func_shelter_b3_dumping_hole_80181D68(D_8006C338[i].field_4);
+                break;
+            }
+            count++;
+        }
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183218);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -44,6 +44,10 @@ typedef struct {
 } DumpingHoleEntityC;
 
 typedef struct {
+    u16 field_0;
+} DumpingHoleEntityD;
+
+typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
     u8                 _pad20[0x4];
@@ -185,7 +189,7 @@ void func_shelter_b3_dumping_hole_801836E0(DumpingHoleState* arg0)
     D_shelter_b3_dumping_hole_8018F4D4 = 0;
     arg0->field_1C                     = work;
     arg0->field_24                     = D_shelter_b3_dumping_hole_8018B7AC;
-    arg0->field_30 += 1;
+    arg0->field_30                    += 1;
 }
 
 void func_shelter_b3_dumping_hole_8018378C(DumpingHoleState* arg0)
@@ -202,7 +206,16 @@ void func_shelter_b3_dumping_hole_8018378C(DumpingHoleState* arg0)
     arg0->field_30 += 1;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183824);
+void func_shelter_b3_dumping_hole_80183824(DumpingHoleState* arg0)
+{
+    DumpingHoleEntityD* ent = (DumpingHoleEntityD*)arg0->field_1C;
+    if ((s16)(ent->field_0 += 1) == 0xF) {
+        ((void (*)(s32))Gp_IncStateF0Ref)(0);
+        Game_Session->unknown_130[0] = 1;
+        Gp_ArmStateF0(1);
+        arg0->field_30 += 1;
+    }
+}
 
 void func_shelter_b3_dumping_hole_801838A0(DumpingHoleState* arg0)
 {
@@ -239,7 +252,7 @@ void func_shelter_b3_dumping_hole_80183950(DumpingHoleState* arg0)
             work->field_0                                              = enemy;
             enemy->field_8                                             = idx << 12;
             D_shelter_b3_dumping_hole_8018F4D4                         = idx + 1;
-            arg0->field_30 += 1;
+            arg0->field_30                                            += 1;
             return;
         }
     }
@@ -288,7 +301,7 @@ void func_shelter_b3_dumping_hole_80183AEC(DumpingHoleState* arg0)
             work->field_0                                              = enemy;
             enemy->field_8                                             = idx << 12;
             D_shelter_b3_dumping_hole_8018F4D4                         = idx + 1;
-            arg0->field_30 += 1;
+            arg0->field_30                                            += 1;
             return;
         }
     }

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -145,7 +145,26 @@ void func_shelter_b3_dumping_hole_801838A0(DumpingHoleState* arg0)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6", func_shelter_b3_dumping_hole_80183950);
+void func_shelter_b3_dumping_hole_80183950(DumpingHoleState* arg0)
+{
+    DumpingHoleEntity* work = Mem_Calloc(8, 0);
+    if (work != NULL) {
+        DumpingHoleTarget* enemy;
+        arg0->field_1C = work;
+        enemy          = (DumpingHoleTarget*)Gp_SpawnEnemyFromTable(&D_80142604, 1, 0, NULL);
+        if (enemy != NULL) {
+            u16 idx;
+            D_shelter_b3_dumping_hole_8018B7BC[arg0->field_36].field_6 = 1;
+            idx                                                        = D_shelter_b3_dumping_hole_8018F4D4;
+            work->field_0                                              = enemy;
+            enemy->field_8                                             = idx << 12;
+            D_shelter_b3_dumping_hole_8018F4D4                         = idx + 1;
+            arg0->field_30 += 1;
+            return;
+        }
+    }
+    Task_Kill((Task*)arg0);
+}
 
 void func_shelter_b3_dumping_hole_80183A00(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -99,7 +99,37 @@ void func_shelter_b3_dumping_hole_80183E08(DumpingHoleState* arg0)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183E6C);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183F04);
+typedef struct {
+    u8  _pad0[0x40];
+    s16 field_40;
+} DumpingHolePairTarget;
+
+typedef struct {
+    DumpingHolePairTarget* field_0;
+    DumpingHolePairTarget* field_4;
+    u8                     _pad8[0x2];
+    u16                    field_A;
+} DumpingHolePairC;
+
+void func_shelter_b3_dumping_hole_80183F04(DumpingHoleState* arg0)
+{
+    DumpingHolePairC* p = (DumpingHolePairC*)arg0->field_1C;
+
+    if (p->field_0 != NULL) {
+        if (p->field_0->field_40 <= 0) {
+            p->field_0 = NULL;
+        }
+    } else {
+        p->field_A |= 1;
+    }
+    if (p->field_4 != NULL) {
+        if (p->field_4->field_40 <= 0) {
+            p->field_4 = NULL;
+        }
+    } else {
+        p->field_A |= 2;
+    }
+}
 
 void func_shelter_b3_dumping_hole_80183F84(Task* task)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -109,7 +109,7 @@ void func_shelter_b3_dumping_hole_80183D34(DumpingHoleState* arg0)
             Gp_DispatchMsg((Task*)t00, 0x7DB, (s32)&desc, 0);
         }
     }
-    ent->field_8   = 0;
+    ent->field_8    = 0;
     arg0->field_30 += 1;
 }
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -4,14 +4,35 @@
 #include "main/task.h"
 
 typedef struct {
-    u8  _pad0[0xA];
-    s16 field_A;
+    u8 _pad0[0x24];
+    u8 field_24;
+    u8 field_25;
+} DumpingHoleP2C;
+
+typedef struct {
+    u8              _pad0[0x2C];
+    DumpingHoleP2C* field_2C;
+} DumpingHoleTarget2;
+
+typedef struct {
+    DumpingHoleTarget2* field_0;
+    u8                  _pad4[0x6];
+    s16                 field_A;
+} DumpingHoleTarget;
+
+typedef struct {
+    DumpingHoleTarget* field_0;
+    u8                 _pad4[0x4];
+    s16                field_8;
+    s16                field_A;
 } DumpingHoleEntity;
 
 typedef struct {
     u8                 _pad0[0x1C];
     DumpingHoleEntity* field_1C;
-    u8                 _pad20[0x16];
+    u8                 _pad20[0x10];
+    s32                field_30;
+    s16                field_34;
     s16                field_36;
 } DumpingHoleState;
 
@@ -19,6 +40,12 @@ typedef struct {
     u8  _pad0[0x6];
     s16 field_6;
 } DumpingHoleB7BC;
+
+typedef struct {
+    u8  field_0;
+    u8  field_1;
+    u16 field_2;
+} DumpingHoleDispatchDesc;
 
 extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
 
@@ -37,7 +64,26 @@ extern SVECTOR D_shelter_b3_dumping_hole_8018B98C[];
 void           Room_Draw13(SVECTOR* v, s32 arg1, s32 arg2);
 void           Room_Draw01(SVECTOR* v, s32 arg1, s32 arg2);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183CA0);
+void func_shelter_b3_dumping_hole_80183CA0(DumpingHoleState* arg0)
+{
+    DumpingHoleDispatchDesc desc;
+    DumpingHoleEntity*      ent = arg0->field_1C;
+    DumpingHoleTarget*      t0  = ent->field_0;
+
+    if (t0 != NULL) {
+        DumpingHoleTarget2* t00 = t0->field_0;
+        DumpingHoleP2C*     p   = t00->field_2C;
+        p->field_24             = 3;
+        p->field_25             = 5;
+        t0->field_A             = 0x900;
+        desc.field_0            = 0;
+        desc.field_1            = 0x2E;
+        desc.field_2            = arg0->field_34;
+        Gp_DispatchMsg((Task*)t00, 0x7DB, (s32)&desc, 0);
+    }
+    ent->field_8    = 0;
+    arg0->field_30 += 1;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183D34);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -22,7 +22,7 @@ typedef struct {
 
 typedef struct {
     DumpingHoleTarget* field_0;
-    u8                 _pad4[0x4];
+    DumpingHoleTarget* field_4;
     s16                field_8;
     s16                field_A;
 } DumpingHoleEntity;
@@ -85,7 +85,32 @@ void func_shelter_b3_dumping_hole_80183CA0(DumpingHoleState* arg0)
     arg0->field_30 += 1;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183D34);
+void func_shelter_b3_dumping_hole_80183D34(DumpingHoleState* arg0)
+{
+    DumpingHoleEntity* ent = arg0->field_1C;
+    DumpingHoleTarget* t   = ent->field_4;
+
+    func_shelter_b3_dumping_hole_80183F04(arg0);
+    if (ent->field_4 != NULL) {
+        if ((s16)(ent->field_8 += 1) < 0x3D) {
+            return;
+        }
+        {
+            DumpingHoleTarget2*     t00 = ent->field_4->field_0;
+            DumpingHoleP2C*         p   = t00->field_2C;
+            DumpingHoleDispatchDesc desc;
+            p->field_24  = 3;
+            p->field_25  = 5;
+            t->field_A   = 0x900;
+            desc.field_0 = 0;
+            desc.field_1 = 0x2E;
+            desc.field_2 = arg0->field_34;
+            Gp_DispatchMsg((Task*)t00, 0x7DB, (s32)&desc, 0);
+        }
+    }
+    ent->field_8   = 0;
+    arg0->field_30 += 1;
+}
 
 void func_shelter_b3_dumping_hole_80183E08(DumpingHoleState* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -3,6 +3,27 @@
 #include "gameplay/D4.h"
 #include "main/task.h"
 
+typedef struct {
+    u8  _pad0[0xA];
+    s16 field_A;
+} DumpingHoleEntity;
+
+typedef struct {
+    u8                 _pad0[0x1C];
+    DumpingHoleEntity* field_1C;
+    u8                 _pad20[0x16];
+    s16                field_36;
+} DumpingHoleState;
+
+typedef struct {
+    u8  _pad0[0x6];
+    s16 field_6;
+} DumpingHoleB7BC;
+
+extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
+
+void func_shelter_b3_dumping_hole_80183F04(DumpingHoleState* arg0);
+
 extern s32     D_shelter_b3_dumping_hole_8018F4D8;
 extern SVECTOR D_shelter_b3_dumping_hole_8018B86C[];
 extern SVECTOR D_shelter_b3_dumping_hole_8018B8BC[];
@@ -20,7 +41,15 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183D34);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183E08);
+void func_shelter_b3_dumping_hole_80183E08(DumpingHoleState* arg0)
+{
+    DumpingHoleEntity* ent = arg0->field_1C;
+    func_shelter_b3_dumping_hole_80183F04(arg0);
+    if (ent->field_A == 3) {
+        D_shelter_b3_dumping_hole_8018B7BC[arg0->field_36].field_6 = 2;
+        Task_Kill((Task*)arg0);
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183E6C);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7.c
@@ -48,6 +48,7 @@ typedef struct {
 } DumpingHoleDispatchDesc;
 
 extern DumpingHoleB7BC D_shelter_b3_dumping_hole_8018B7BC[];
+extern TaskDesc        D_shelter_b3_dumping_hole_8018B83C;
 
 void func_shelter_b3_dumping_hole_80183F04(DumpingHoleState* arg0);
 
@@ -122,7 +123,20 @@ void func_shelter_b3_dumping_hole_80183E08(DumpingHoleState* arg0)
     }
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_7", func_shelter_b3_dumping_hole_80183E6C);
+void func_shelter_b3_dumping_hole_80183E6C(s16 arg0, s16 arg1, s16 arg2)
+{
+    switch (arg1) {
+        case 0:
+            Task_SpawnFromTable(&D_shelter_b3_dumping_hole_8018B83C, 1, (arg0 << 16) + arg2, 0);
+            break;
+        case 1:
+            Task_SpawnFromTable(&D_shelter_b3_dumping_hole_8018B83C, 2, (arg0 << 16) + arg2, 0);
+            break;
+        case 2:
+            Task_SpawnFromTable(&D_shelter_b3_dumping_hole_8018B83C, 3, (arg0 << 16) + arg2, 0);
+            break;
+    }
+}
 
 typedef struct {
     u8  _pad0[0x40];

--- a/tools/difficult_functions
+++ b/tools/difficult_functions
@@ -6,3 +6,4 @@ func_shelter_b1_golem_freezer_1_8017E254 5 ~87%
 func_actor_400600_80137840 30 98.837
 func_shelter_b3_dumping_hole_8017FF14 1 90
 func_shelter_b3_dumping_hole_8017FF14 3 ~98%
+func_shelter_b3_dumping_hole_80181560 7 98%


### PR DESCRIPTION
Matches 11 shelter_b3_dumping_hole room-task functions (all local per-TU structs, no pointer arithmetic; full unscoped build matches, SLUS_010.42 OK):

- 80183E08 / 80183C38 / 80183A98 - entity-state gates that mark a B7BC slot and kill the task
- 801838A0 - counts B7BC slots at state 2; releases + kills when all 16 are set
- 80183CA0 / 80183A00 / 80183B9C - target-chain Gp_DispatchMsg dispatchers (0x7DB)
- 80183950 / 80183AEC - Mem_Calloc + Gp_SpawnEnemyFromTable spawn tasks
- 8018378C - three-step B7BC dispatch loop
- 80183198 - FsFolderSlot table scan calling the file-open helper