### PR TITLE
Match shelter_b3_dumping_hole relocation walker

### DIFF
--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -3540,6 +3540,32 @@ p = &base[(s8)arg0];
 `SndBankSlot_Free` needs this form so `SndHeap_Free` can take `p->field_0` with the
 base already in `$v0` before the stride multiply lands in `$s0`.
 
+**Matrix cluster on an embedded MATRIX — first element on the struct base, rest
+through an aliased pointer.** Writing a scaled-identity into a `GsCOORDINATE2`'s
+embedded `coord` (`MATRIX` at +4) with the usual s32-cast idiom
+(`*(s32*)&coord->coord.m[0][0] = 0x1000; ...`) lets GCC address every element
+off the struct base (`sw …,8(s0)`, `sw …,0xC(s0)`, …). The target instead
+materializes `addiu vN,s0,4` once and stores the *cluster* through it while the
+first element and any far field (`sub` at +0x4C) stay on `s0`. Reproduce by
+aliasing only the tail:
+
+```c
+MATRIX* m = &coord->coord;
+coord->sub                   = mem->field_8;   /* on s0 */
+*(s32*)&coord->coord.m[0][0] = 0x1000;         /* on s0, offset 4 */
+*(s32*)&m->m[0][2]           = 0;              /* on s0+4 base */
+*(s32*)&m->m[1][1]           = 0x1000;
+*(s32*)&m->m[2][0]           = 0;
+m->m[2][2]                   = 0x1000;
+```
+
+Two levers together: (1) `m00` written through `coord->coord` (not `m`) keeps it
+on `s0` while the four aliased stores form and reuse `s0+4`; (2) doing the far
+`coord->sub` store *before* `m00` (load `mem->field_8` first) keeps the coord arg
+live in `$a0` across the earlier branch so the following `Gp_UpdateCoord(coord)`
+needs no `move a0,s0` reload — writing `m00` first re-derives `a0` and costs one
+insn. `func_shelter_b3_dumping_hole_80186D4C` is the worked example.
+
 **Base before index without a second pseudo — assign inside the subscript.**
 The local-pointer form above costs a register: a user pointer variable splits
 the address into two pseudos (`lui $v0, %hi(tbl)` / `addiu $a2, $v0, %lo(tbl)`)

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -60214,3 +60214,18 @@ extension as its own early statement, so it emits right after the first init.
 (`if (count == arg2)`). GCC still hoists the single extension out of the loop,
 but now schedules it *among* the other loop-invariants (after `i=0` and the
 compare constant), matching retail. `func_shelter_b3_dumping_hole_80183198`.
+
+## Chained signed divides by 15: reuse one local, not two
+
+func_shelter_b3_dumping_hole_80182AA0 (POLY_G3 colour ramp) does two
+"(global << k) / 15" signed divides back to back, storing the quotients to
+different prim fields. Writing them into two separate locals
+("c1 = a/15; ...; c2 = b/15;") makes GCC 2.8.1 keep an extra dead pseudo for the
+first divide's dividend, which shifts the whole mult/mfhi/addu/sra/subu
+magic-divide sequence onto $v1 instead of $v0 (it should reuse the register that
+held the 0x30 "code" store). Reuse ONE local across both:
+"c1 = a/15; r=g=b=c1; c1 = b/15; c2 = c1;". The "c2 = c1" copy (not a fresh
+"c2 = b/15") is what lets the first divide reuse the freed register. Found by
+decomp-permuter distance search (see [[pe2-windows-toolchain-gotchas]] 3e for how
+the permuter runs on the spaced Windows checkout via a bind mount), confirmed by
+port.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -8346,6 +8346,33 @@ entry = D_8006273C[idx] + ((D_80062738 + product) & 0xFFFF);
 on the stage pointer when the target loads `Game_Session` into `$v1` (with
 an argument live in `$s1`) rather than `$a0`.
 
+**The base must be an early integer local, not the cast inline, or the `%hi`
+schedules late.** `idx * sizeof(T) + (s32)PtrGlobal` inline flips the operand
+order but leaves the base `lui %hi(PtrGlobal)` scheduled *after* the index
+`sll`s (one-instruction reorder, ~99.5%). Hoist the pointer read into a plain
+`s32` local first so its `%hi/%lo` load leads the address math the way the
+subscript form does:
+
+```c
+/* 99.5% — addu order right, but lui %hi of base sits after the index slls */
+e = (T*)(arg0 * sizeof(T) + (s32)D_PtrGlobal);
+
+/* 100% — base %hi hoisted to the top like &D_PtrGlobal[arg0] would */
+s32 base = (s32)D_PtrGlobal;
+e = (T*)(arg0 * sizeof(T) + base);
+```
+
+`func_shelter_b3_dumping_hole_80182FD0` (a 12-byte-stride array search over
+`D_..8018F4BC[arg0]`) is the pure example: the clean `&D_..8018F4BC[arg0]`
+subscript gives base-first `addu` (99.52%, one word off); the early-`s32`-base
+integer form matches. The subscript form is base-first because GCC treats the
+array pointer as the addressing base regardless of `a[b]`/`b[a]` order or a
+`u8*`-cast offset; only the pure-integer add with the `mult` outranking a plain
+base REG (`commutative_operand_precedence`) puts the offset first. The idiom
+matches the `(GpEvt12*)(idx * sizeof(GpEvt12) + base)` and
+`(GlyphUvwh*)((code & 0x3FF) * sizeof(GlyphUvwh) + (s32)table)` forms already in
+`src/gameplay/3CD8.c`.
+
 ## Pre-increment store `*++p = f()` fills `jal` delay with the previous store
 
 When walking a buffer and writing values that each depend on a call (e.g.

--- a/DECOMPILATION_LEARNINGS.md
+++ b/DECOMPILATION_LEARNINGS.md
@@ -767,6 +767,36 @@ locals; with a single roll the local is what hurts.
 `ActorsShared80169dbc` (`src/actors/lib/actors_shared_80169dbc.c`) is the
 example.
 
+Roll through the global for *chained* rolls too, when the target keeps **both**
+`sw Gp_LcgState` stores. When roll2 derives from roll1's register (the target
+computes `roll2 = roll1*5+K` with no reload, then stores both at the block end),
+the natural two-locals form drops a store:
+
+```c
+rng2 = Gp_LcgState * 5 + 0x71357911;   /* roll1 */
+...field16 from rng2...
+rng3 = rng2 * 5 + 0x71357911;          /* roll2 from the local, no reload */
+...field20 from rng3...
+Gp_LcgState = rng2;
+Gp_LcgState = rng3;   /* the two stores end up adjacent -> GCC DSEs the first */
+```
+
+GCC generally does not dead-store-eliminate stores to a global, but two writes
+that schedule **adjacent** with no intervening memory read of that global are
+the case it does catch, so only one `sw Gp_LcgState` survives (`insert`/`delete`
+= 1). Roll through the global instead and read it back between the writes:
+
+```c
+Gp_LcgState = Gp_LcgState * 5 + 0x71357911;          /* store roll1 */
+W->field_16 = 0xFFF6 - ((Gp_LcgState >> 16) & 7);    /* CSE'd to roll1 reg */
+Gp_LcgState = Gp_LcgState * 5 + 0x71357911;          /* roll2 = roll1 reg *5+K, no reload; store */
+W->field_20 = (Gp_LcgState >> 16) & 7;               /* CSE'd to roll2 reg */
+```
+
+The intervening field-store reads keep the two `sw` non-adjacent, so both
+survive, while CSE still feeds roll2 from roll1's register (no `lw` reload).
+`func_shelter_b3_dumping_hole_8017DCFC` is the example.
+
 ## Earlyclobber empty asm copies an SI value (`move`) instead of `andi` / in-place `sll`
 
 A value loaded `lhu` into an SI temp and reused for both `field += step` and

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -24,7 +24,9 @@ typedef struct {
     u8    pad_34[0x4];
     s16   field_38;
     s16   field_3A;
-    u8    pad_3C[0xC];
+    u8    pad_3C[0x6];
+    u16   field_42;
+    u8    pad_44[0x4];
     s16   field_48;
     u8    pad_4A[0x2];
     u16   field_4C;
@@ -55,7 +57,110 @@ void func_shelter_b3_dumping_hole_8017D9A8(Task* task)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017DA00);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017DCFC);
+typedef struct {
+    s16 field_0;
+    s16 field_2;
+    s16 field_4;
+    u8  pad_6[0x2];
+    s16 field_8;
+    u8  pad_A[0xA];
+    s16 field_14;
+    s16 field_16;
+    s16 field_18;
+    u8  pad_1A[0x2];
+    s16 field_1C;
+    u16 field_1E;
+    u16 field_20;
+} DumpingHoleAnimWork;
+
+typedef struct {
+    s16 field_0;
+    s16 field_2;
+    s16 field_4;
+    s16 field_6;
+    s16 field_8;
+    s16 field_A;
+} DumpingHoleAnimFrame;
+
+extern u32                  Gp_LcgState;
+extern s16                  D_shelter_b3_dumping_hole_80188154[];
+extern DumpingHoleAnimFrame D_shelter_b3_dumping_hole_801880B8[];
+
+u16 func_shelter_b3_dumping_hole_8017DA00(GsCOORDINATE2* coord, s16 arg1, s16 arg2,
+                                          s16 arg3, s16 arg4, s16 arg5, s16 arg6,
+                                          s16 arg7, s16 arg8, s16 arg9);
+
+void func_shelter_b3_dumping_hole_8017DCFC(Task* arg0)
+{
+    DumpingHoleAnimWork* W      = (DumpingHoleAnimWork*)arg0->idMap;
+    GsCOORDINATE2*       coord  = ((TmdObject*)arg0->extra)->field_8;
+    DumpingHoleEntity*   entity = D_shelter_b3_dumping_hole_8018F4A8->field_1C;
+
+    if (entity->field_42 == 1) {
+        Task_Kill((Task*)arg0);
+        return;
+    }
+
+    switch (arg0->state) {
+        case 0:
+            coord->sub        = &Gfx_ViewCoord;
+            coord->coord.t[0] = W->field_0;
+            coord->coord.t[1] = W->field_2;
+            coord->coord.t[2] = W->field_4;
+            arg0->state++;
+            return;
+        case 1:
+            if (entity->field_42 != 2) {
+                return;
+            }
+            W->field_1C = 5;
+            W->field_14 = 0;
+            W->field_18 = 0;
+            Gp_LcgState = Gp_LcgState * 5 + 0x71357911;
+            W->field_16 = 0xFFF6 - ((Gp_LcgState >> 16) & 7);
+            Gp_LcgState = Gp_LcgState * 5 + 0x71357911;
+            W->field_20 = (Gp_LcgState >> 16) & 7;
+            arg0->state++;
+            return;
+        case 2:
+            if (W->field_20 == 0) {
+                arg0->state = 3;
+            } else {
+                W->field_20--;
+            }
+            return;
+        case 3: {
+            s32 t1e     = W->field_1E + 1;
+            W->field_1E = t1e;
+            if (D_shelter_b3_dumping_hole_80188154[W->field_1C] < (s16)t1e) {
+                *(u16*)&W->field_1C = *(u16*)&W->field_1C + 1;
+                W->field_1E         = 0;
+                if (*(u16*)&D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_0 == 0xFFFF) {
+                    Task_Kill((Task*)arg0);
+                    return;
+                }
+            }
+            break;
+        }
+        default:
+            return;
+    }
+
+    coord->coord.t[1] += W->field_16;
+    if (func_shelter_b3_dumping_hole_8017DA00(
+            coord,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_8,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_A,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_2,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_6,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_0,
+            D_shelter_b3_dumping_hole_801880B8[W->field_1C].field_4,
+            W->field_8, 0x43C0, 0) != 0) {
+        Task_Kill((Task*)arg0);
+        return;
+    }
+    coord->flg = 0;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017DF90);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "gameplay/1BC.h"
 #include "gameplay/3A34.h"
 #include "gameplay/3CD8.h"
 #include "gameplay/D4.h"
@@ -164,7 +165,109 @@ void func_shelter_b3_dumping_hole_8017DCFC(Task* arg0)
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017DF90);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017E440);
+extern s16 D_shelter_b3_dumping_hole_80188184[];
+
+void func_shelter_b3_dumping_hole_8017E440(Task* arg0)
+{
+    DumpingHoleAnimWork* work  = (DumpingHoleAnimWork*)arg0->idMap;
+    GsCOORDINATE2*       coord = ((TmdObject*)arg0->extra)->field_8;
+    SVECTOR              vec;
+    s32                  sa1;
+    u32                  roll1;
+    u32                  roll2;
+    s32                  base18;
+    s16                  var0;
+    s16                  delta;
+
+    if (*(u16*)&D_shelter_b3_dumping_hole_8018F4A8->field_1C->field_48 == 1) {
+        Task_Kill(arg0);
+        return;
+    }
+
+    switch (arg0->state) {
+        case 0:
+            coord->sub = &Gfx_ViewCoord;
+            Gp_ComposeParentWorld((GsCOORDINATE2*)arg0->spawnArg2, &coord->coord, &vec);
+            coord->coord.t[0] = vec.vx;
+            coord->coord.t[1] = vec.vy;
+            coord->coord.t[2] = vec.vz;
+            arg0->idMap       = (TaskIdMap*)Mem_Malloc(0x24, 0);
+            if (arg0->idMap == NULL) {
+                Task_Kill(arg0);
+                return;
+            }
+            work = (DumpingHoleAnimWork*)arg0->idMap;
+            Mem_Set(work, 0, 0x24);
+            work->field_16 = -0xA;
+            work->field_14 = 0;
+            work->field_18 = 0;
+            work->field_8  = 0x1000;
+            work->field_14 = 0;
+            roll1          = Gp_LcgState * 5 + 0x71357911;
+            work->field_16 = 0xFFF1 - ((roll1 >> 16) & 7);
+            sa1            = arg0->spawnArg1;
+            Gp_LcgState    = roll1;
+            if (sa1 == 0) {
+                roll2       = roll1 * 5 + 0x71357911;
+                base18      = work->field_18;
+                Gp_LcgState = roll2;
+                if ((roll2 >> 16) & 1) {
+                    Gp_LcgState = roll2 * 5 + 0x71357911;
+                    var0        = base18 + ((Gp_LcgState >> 16) & 1);
+                } else {
+                    Gp_LcgState = roll2 * 5 + 0x71357911;
+                    var0        = base18 - ((Gp_LcgState >> 16) & 1);
+                }
+                work->field_18 = var0;
+            } else {
+                if (sa1 < 0) {
+                    Gp_LcgState = roll1 * 5 + 0x71357911;
+                    delta       = *(u16*)&work->field_18 + ((u16)arg0->spawnArg1 - ((Gp_LcgState >> 16) & 1));
+                } else {
+                    Gp_LcgState = roll1 * 5 + 0x71357911;
+                    delta       = *(u16*)&work->field_18 + ((u16)arg0->spawnArg1 + ((Gp_LcgState >> 16) & 1));
+                }
+                work->field_18 = delta;
+            }
+            work->field_1C = 0;
+            Gp_LcgState    = Gp_LcgState * 5 + 0x71357911;
+            work->field_20 = (Gp_LcgState >> 16) & 7;
+            arg0->state++;
+            return;
+        case 1:
+            if (work->field_20 == 0) {
+                arg0->state = 2;
+            } else {
+                work->field_20--;
+            }
+            return;
+        case 2: {
+            s32 t1e        = work->field_1E + 1;
+            work->field_1E = t1e;
+            if (D_shelter_b3_dumping_hole_80188184[work->field_1C] < (s16)t1e) {
+                *(u16*)&work->field_1C = *(u16*)&work->field_1C + 1;
+                work->field_1E         = 0;
+                if (*(u16*)&D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_0 == 0xFFFF) {
+                    Task_Kill(arg0);
+                    return;
+                }
+            }
+            coord->coord.t[1] += work->field_16;
+            coord->coord.t[2] += work->field_18;
+            func_shelter_b3_dumping_hole_8017DA00(
+                coord,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_8,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_A,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_2,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_6,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_0,
+                D_shelter_b3_dumping_hole_801880B8[work->field_1C].field_4,
+                work->field_8, 0x43C0, 0);
+            coord->flg = 0;
+            return;
+        }
+    }
+}
 
 typedef struct {
     s32 field_0;

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3.c
@@ -17,7 +17,8 @@ extern TaskDesc D_shelter_b3_dumping_hole_80188BC8;
 extern s16      D_shelter_b3_dumping_hole_8018809C;
 
 typedef struct {
-    u8    pad_00[0x28];
+    u8    pad_00[0x24];
+    Task* field_24;
     Task* field_28;
     Task* field_2C;
     s16   field_30;
@@ -25,9 +26,11 @@ typedef struct {
     u8    pad_34[0x4];
     s16   field_38;
     s16   field_3A;
-    u8    pad_3C[0x6];
+    u8    pad_3C[0x4];
+    s16   field_40;
     u16   field_42;
-    u8    pad_44[0x4];
+    s16   field_44;
+    s16   field_46;
     s16   field_48;
     u8    pad_4A[0x2];
     u16   field_4C;
@@ -460,7 +463,34 @@ void func_shelter_b3_dumping_hole_8017FEF4(s16 arg0)
     p->field_3A          = 0;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_3", func_shelter_b3_dumping_hole_8017FF14);
+extern s8 D_8007218A;
+extern u8 D_80073BA9;
+extern u8 D_shelter_b3_dumping_hole_801881CC;
+
+void func_shelter_b3_dumping_hole_8017FF14(void)
+{
+    register DumpingHoleState*  st asm("s0")  = D_shelter_b3_dumping_hole_8018F4A8;
+    register DumpingHoleEntity* ent asm("s1") = st->field_1C;
+    DumpingHoleEntity*          ent2;
+    s32                         desc[5];
+
+    Gp_DispatchMsg(ent->field_2C, 0x7D5, 2, 0);
+    Gp_DispatchMsg(ent->field_24, 0x3F3, 1, 0);
+    Gp_DispatchMsg(ent->field_24, 0x3E9, (s32)&D_shelter_b3_dumping_hole_801881CC, 0);
+    ent2    = st->field_1C;
+    desc[0] = D_80073BA9 + (D_8007218A == 1 ? 1 : 0x22);
+    desc[1] = 9;
+    desc[2] = 0;
+    desc[3] = 0;
+    desc[4] = 0;
+    Gp_DispatchMsg(ent2->field_24, 0x3E8, (s32)desc, 0);
+    ent->field_40 = 2;
+    ent->field_46 = 1;
+    ent->field_42 = 1;
+    ent->field_4C = 1;
+    ent->field_44 = 1;
+    CdCmd_CancelReplaceAndActivate();
+}
 
 void func_shelter_b3_dumping_hole_8017FFF4(void)
 {
@@ -504,8 +534,6 @@ typedef struct {
 
 extern DumpingHoleState4* D_shelter_b3_dumping_hole_8018F4AC;
 extern s16                D_shelter_b3_dumping_hole_8018F4B0;
-extern s8                 D_8007218A;
-extern u8                 D_80073BA9;
 
 void func_shelter_b3_dumping_hole_80181430(void)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -93,7 +93,72 @@ void func_shelter_b3_dumping_hole_80181C8C(void)
     func_shelter_b3_dumping_hole_80182AA0();
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181D68);
+typedef struct {
+    /* 0x00 */ char magic[0x8];
+    /* 0x08 */ s32  field_8;
+    /* 0x0C */ s32  field_C;
+    /* 0x10 */ s32  field_10;
+} Reloc80181D68Hdr;
+
+typedef struct {
+    /* 0x00 */ u8  pad[0x8];
+    /* 0x08 */ s32 field_8;
+} Reloc80181D68Entry1;
+
+typedef struct {
+    /* 0x00 */ s16                 count;
+    /* 0x02 */ u8                  pad[0xE];
+    /* 0x10 */ Reloc80181D68Entry1 entries[1];
+} Reloc80181D68Table1;
+
+typedef struct {
+    /* 0x00 */ s32 count;
+    /* 0x04 */ s32 entries[1];
+} Reloc80181D68Table2;
+
+extern char D_shelter_b3_dumping_hole_8017D650[];
+extern s32  D_shelter_b3_dumping_hole_8018F4B8;
+extern s32  D_shelter_b3_dumping_hole_8018F4B4;
+
+s32 func_shelter_b3_dumping_hole_80181D68(s32 arg0)
+{
+    Reloc80181D68Hdr*    hdr = (Reloc80181D68Hdr*)arg0;
+    Reloc80181D68Entry1* r;
+    s32*                 q;
+    s32                  n1;
+    s32                  n2;
+    s32                  i;
+
+    if (strncmp((char*)hdr, D_shelter_b3_dumping_hole_8017D650, 3) != 0) {
+        return 0;
+    }
+    if (hdr->field_8 > 0) {
+        hdr->field_8  += (s32)hdr;
+        hdr->field_C  += (s32)hdr;
+        hdr->field_10 += (s32)hdr;
+        n1             = ((Reloc80181D68Table1*)hdr->field_C)->count;
+        r              = &((Reloc80181D68Table1*)hdr->field_C)->entries[0];
+        for (i = 0; i < n1; i++) {
+            if (r->field_8 != -1) {
+                r->field_8 += (s32)hdr;
+            } else {
+                r++;
+            }
+            r++;
+        }
+        n2 = ((Reloc80181D68Table2*)hdr->field_10)->count;
+        q  = &((Reloc80181D68Table2*)hdr->field_10)->entries[0];
+        for (i = 0; i < n2; i++) {
+            if (*q != 0) {
+                *q += (s32)hdr;
+            }
+            q++;
+        }
+    }
+    D_shelter_b3_dumping_hole_8018F4B8 = hdr->field_8;
+    D_shelter_b3_dumping_hole_8018F4B4 = hdr->field_10 + 4;
+    return 1;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", RoomsShared801830f0Sub);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -14,7 +14,8 @@ typedef struct {
     u8  field_1;
     u8  _pad2[0x2];
     u8  field_4;
-    u8  _pad5[0x3];
+    u8  field_5;
+    u8  _pad6[0x2];
     s32 field_8;
 } DumpingHoleSpawnElem;
 
@@ -280,7 +281,23 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80182F18);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80182FD0);
+s32 func_shelter_b3_dumping_hole_80182FD0(s32 arg0)
+{
+    s32                   sentinel = -1;
+    s32                   base     = (s32)D_shelter_b3_dumping_hole_8018F4BC;
+    s32                   target   = D_shelter_b3_dumping_hole_8018F4CA;
+    DumpingHoleSpawnElem* e        = (DumpingHoleSpawnElem*)(arg0 * sizeof(DumpingHoleSpawnElem) + base);
+
+loop:
+    if (e->field_8 != sentinel) {
+        if (e->field_5 != target) {
+            e++;
+            arg0++;
+            goto loop;
+        }
+    }
+    return arg0;
+}
 
 void func_shelter_b3_dumping_hole_80183024(Task* arg0)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -7,6 +7,7 @@
 #include "main/stage.h"
 #include "gameplay/3CD8.h"
 #include "main/display.h"
+#include "psyq/libgpu.h"
 
 typedef struct {
     u8  field_0;
@@ -198,7 +199,78 @@ INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_801829B4);
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80182AA0);
+typedef struct {
+    /* 0x00 */ u32 tag;
+    /* 0x04 */ u8  r;
+    /* 0x05 */ u8  g;
+    /* 0x06 */ u8  b;
+    /* 0x07 */ u8  code;
+    /* 0x08 */ s16 field_8;
+    /* 0x0A */ s16 field_A;
+    /* 0x0C */ u8  field_C;
+    /* 0x0D */ u8  field_D;
+    /* 0x0E */ u8  field_E;
+    /* 0x0F */ u8  pad_F;
+    /* 0x10 */ s16 field_10;
+    /* 0x12 */ s16 field_12;
+    /* 0x14 */ u8  field_14;
+    /* 0x15 */ u8  field_15;
+    /* 0x16 */ u8  field_16;
+    /* 0x17 */ u8  pad_17;
+    /* 0x18 */ s16 field_18;
+    /* 0x1A */ s16 field_1A;
+} Prim82AA0;
+
+extern s32 D_shelter_b3_dumping_hole_8018B670;
+extern s32 D_shelter_b3_dumping_hole_8018B674;
+extern u16 D_shelter_b3_dumping_hole_8018F4CC;
+extern u16 D_shelter_b3_dumping_hole_8018F4CE;
+
+void func_shelter_b3_dumping_hole_80182AA0(void)
+{
+    Prim82AA0* prim;
+    s32        c1;
+    s32        c2;
+
+    if (D_shelter_b3_dumping_hole_8018F4D0 != 0) {
+        D_shelter_b3_dumping_hole_8018F4D0 -= 1;
+        return;
+    }
+    prim           = (Prim82AA0*)Gpu_PrimCursor;
+    Gpu_PrimCursor = (DR_TPAGE*)(prim + 1);
+    setlen(prim, 6);
+    prim->code     = 0x30;
+    c1             = (D_shelter_b3_dumping_hole_8018B670 << 7) / 15;
+    prim->r        = c1;
+    prim->g        = c1;
+    prim->b        = c1;
+    c1             = (D_shelter_b3_dumping_hole_8018B670 * 192) / 15;
+    c2             = c1;
+    prim->field_C  = c2;
+    prim->field_D  = c2;
+    prim->field_E  = c2;
+    prim->field_14 = c2;
+    prim->field_15 = c2;
+    prim->field_16 = c2;
+    prim->field_8  = D_shelter_b3_dumping_hole_8018F4CC + 3;
+    prim->field_A  = D_shelter_b3_dumping_hole_8018F4CE;
+    prim->field_10 = D_shelter_b3_dumping_hole_8018F4CC;
+    prim->field_18 = D_shelter_b3_dumping_hole_8018F4CC + 7;
+    prim->field_12 = D_shelter_b3_dumping_hole_8018F4CE - 7;
+    prim->field_1A = D_shelter_b3_dumping_hole_8018F4CE - 7;
+    addPrim(&Gpu_CurrentOt[2], prim);
+    if (D_shelter_b3_dumping_hole_8018B674 == 0) {
+        D_shelter_b3_dumping_hole_8018B670 += 1;
+        if (D_shelter_b3_dumping_hole_8018B670 >= 0xF) {
+            D_shelter_b3_dumping_hole_8018B674 = 1;
+        }
+    } else {
+        D_shelter_b3_dumping_hole_8018B670 -= 1;
+        if (D_shelter_b3_dumping_hole_8018B670 < 9) {
+            D_shelter_b3_dumping_hole_8018B674 = 0;
+        }
+    }
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80182C24);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5.c
@@ -160,7 +160,39 @@ s32 func_shelter_b3_dumping_hole_80181D68(s32 arg0)
     return 1;
 }
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", RoomsShared801830f0Sub);
+extern s16 D_shelter_b3_dumping_hole_8018F4C0;
+extern s16 D_shelter_b3_dumping_hole_8018F4C2;
+extern s16 D_shelter_b3_dumping_hole_8018F4C4;
+extern s16 D_shelter_b3_dumping_hole_8018F4C8;
+extern s16 D_shelter_b3_dumping_hole_8018F4CA;
+extern u8  D_shelter_b3_dumping_hole_8018F4D0;
+
+s32 func_shelter_b3_dumping_hole_80182FD0(s32 arg0);
+s32 func_shelter_b3_dumping_hole_80182C24(s32 arg0);
+s16 func_shelter_b3_dumping_hole_801829B4(u16* arg0);
+s32 func_shelter_b3_dumping_hole_80182E50(s32 arg0);
+
+s32 RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2)
+{
+    DumpingHoleSpawnElem* entry;
+
+    entry                              = ((DumpingHoleSpawnElem**)D_shelter_b3_dumping_hole_8018F4B4)[arg0];
+    D_shelter_b3_dumping_hole_8018F4BC = entry;
+    if (entry == NULL) {
+        return 1;
+    }
+    D_shelter_b3_dumping_hole_8018F4CA = arg1;
+    D_shelter_b3_dumping_hole_8018F4C6 = func_shelter_b3_dumping_hole_80182FD0(1);
+    D_shelter_b3_dumping_hole_8018F4C4 = arg2;
+    D_shelter_b3_dumping_hole_8018F4C0 = func_shelter_b3_dumping_hole_80182C24(
+        D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_8);
+    D_shelter_b3_dumping_hole_8018F4C2 = func_shelter_b3_dumping_hole_801829B4(
+        (u16*)D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_8);
+    D_shelter_b3_dumping_hole_8018F4C8 = func_shelter_b3_dumping_hole_80182E50(
+        D_shelter_b3_dumping_hole_8018F4BC[D_shelter_b3_dumping_hole_8018F4C6].field_8);
+    D_shelter_b3_dumping_hole_8018F4D0 = 0x1E;
+    return 0;
+}
 
 INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_5", func_shelter_b3_dumping_hole_80181F80);
 

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_6.c
@@ -94,7 +94,7 @@ void RoomsShared801830f0Sub(s16 arg0, s16 arg1, s32 arg2);
 
 void func_shelter_b3_dumping_hole_801833EC(DumpingHoleState* arg0);
 void func_shelter_b3_dumping_hole_80183E6C(s16 arg0, s16 arg1, s16 arg2);
-void func_shelter_b3_dumping_hole_80181D68(s32 arg0);
+s32  func_shelter_b3_dumping_hole_80181D68(s32 arg0);
 
 void func_shelter_b3_dumping_hole_80183144(s16 arg0, s16 arg1, s16 arg2)
 {

--- a/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_9.c
+++ b/src/rooms/shelter_b3_dumping_hole/shelter_b3_dumping_hole_9.c
@@ -1,3 +1,72 @@
 #include "common.h"
+#include "main/task.h"
+#include "main/tmd.h"
+#include "gameplay/3CD8.h"
+#include "gameplay/gameplay.h"
+#include "rooms/room_common.h"
+#include <psyq/libgs.h>
 
-INCLUDE_ASM("rooms/nonmatchings/shelter_b3_dumping_hole/shelter_b3_dumping_hole_9", func_shelter_b3_dumping_hole_80186D4C);
+typedef struct {
+    u8             pad0[8];
+    GsCOORDINATE2* field_8;
+    u8             pad_C[0x16];
+    u16            field_22;
+} ClumpMem;
+
+void func_shelter_b3_dumping_hole_80186D4C(Task* arg0)
+{
+    ClumpMem*      mem;
+    GsCOORDINATE2* coord;
+    MATRIX*        m;
+    s32            i;
+
+    mem   = (ClumpMem*)arg0->spawnArg2;
+    coord = (GsCOORDINATE2*)((TmdObject*)arg0->extra)->field_8;
+    if (Gp_State1C->field_4 != 0) {
+        Room_Draw41(coord, ((s16)mem->field_22 / 2) & 0xFFFF, 0x380);
+        if (Gp_State1C->field_4 >= 4) {
+            Gp_ReleaseState1CMem(mem, arg0);
+        }
+        return;
+    }
+    if (arg0->state == 0) {
+        m                            = &coord->coord;
+        coord->sub                   = mem->field_8;
+        *(s32*)&coord->coord.m[0][0] = 0x1000;
+        *(s32*)&m->m[0][2]           = 0;
+        *(s32*)&m->m[1][1]           = 0x1000;
+        *(s32*)&m->m[2][0]           = 0;
+        m->m[2][2]                   = 0x1000;
+        coord->coord.t[2]            = 0;
+        coord->coord.t[1]            = 0;
+        coord->coord.t[0]            = 0;
+        coord->flg                   = 0;
+        Gp_UpdateCoord(coord);
+        arg0->state = 1;
+    }
+    mem->field_22 += 1;
+    switch (arg0->spawnArg1) {
+        case 0:
+            Gp_SpawnEff(0x6019A, coord, 0x14002400, NULL);
+            arg0->spawnArg1 = 1;
+            return;
+        case 1:
+            Room_Draw41(coord, ((s16)mem->field_22 / 2) & 0xFFFF, 0x380);
+            if (!(mem->field_22 & 1)) {
+                Gp_SpawnEff(0x6019A, coord, 0x1001400, NULL);
+            }
+            mem->field_22 += 1;
+            return;
+        case 2:
+            Gp_SpawnEff(0x6019A, coord, 0x10002380, NULL);
+            for (i = 0; i < 4; i++) {
+                Gp_SpawnEff(0x6019A, coord, 0x2002400, NULL);
+                Gp_SpawnEff(0x60199, coord, 0x2202300, NULL);
+            }
+            arg0->spawnArg1 = 3;
+            return;
+        case 3:
+            Gp_ReleaseState1CMem(mem, arg0);
+            return;
+    }
+}


### PR DESCRIPTION
Matches func_shelter_b3_dumping_hole_80181D68, the resource-relocation walker in unit 5 (strncmp magic gate, relocates three header offset fields against the load base, walks two relocation tables, publishes two globals). More matches to follow on this branch.